### PR TITLE
ci: speedup the Tests workflow in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         cache_nonce: [ 1 ]
-        nim_version: [ 1.2.18, 1.4.8, 1.6.6 ]
+        nim_version: [ 1.2.18, 1.6.6 ]
         platform:
           - {
             icon: 🐧,
@@ -40,17 +40,16 @@ jobs:
         shell: ${{ matrix.platform.shell }} {0}
 
     steps:
-      # - name: Install tools and libraries via APT (Linux)
-      #   if: matrix.platform.os == 'ubuntu'
-      #   run: |
-      #     sudo apt update
-      #     sudo apt install -y \
-      #       ...
+      - name: Install tools and libraries via APT (Linux)
+        if: matrix.platform.os == 'ubuntu'
+        run: |
+          # sudo apt update
+          # sudo apt install -y \
+          #   ...
 
       - name: Install tools and libraries via Homebrew (macOS)
         if: matrix.platform.os == 'macos'
         run: |
-          brew update
           brew install \
             findutils
 


### PR DESCRIPTION
Don't build with Nim v1.4, building with v1.2 and v1.6 should be enough.

Don't manually run `brew update` because `brew` will automatically do that on an as-needed basis when running `brew install`.