### PR TITLE
check for out-of-memory errors re: sqlite3_column_text/blob/bytes

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,2 +1,10 @@
 --threads:on
 --tlsEmulation:off
+
+when (NimMajor, NimMinor) == (1, 2):
+  switch("hint", "Processing:off")
+  switch("hint", "XDeclaredButNotUsed:off")
+  switch("warning", "ObservableStores:off")
+
+when (NimMajor, NimMinor) > (1, 2):
+  switch("hint", "XCannotRaiseY:off")

--- a/datastore/sqlite.nim
+++ b/datastore/sqlite.nim
@@ -3,16 +3,22 @@ import pkg/questionable/results
 import pkg/sqlite3_abi
 import pkg/upraises
 
-push: {.upraises: [].}
-
 # Adapted from:
 # https://github.com/status-im/nwaku/blob/master/waku/v2/node/storage/sqlite.nim
+
+# see https://www.sqlite.org/c3ref/column_database_name.html
+# can pass `--forceBuild:on` to the Nim compiler if a SQLite build without
+# `-DSQLITE_ENABLE_COLUMN_METADATA` option is stuck in the build cache,
+# e.g. `nimble test --forceBuild:on`
+{.passC: "-DSQLITE_ENABLE_COLUMN_METADATA".}
+
+push: {.upraises: [].}
 
 type
   AutoDisposed*[T: ptr|ref] = object
     val*: T
 
-  DataProc* = proc(s: RawStmtPtr) {.closure.}
+  DataProc* = proc(s: RawStmtPtr) {.closure, gcsafe.}
 
   NoParams* = tuple # empty tuple
 

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -160,15 +160,6 @@ proc dataCol*(
 
     let
       dataLen = sqlite3_column_bytes(s, i)
-
-    # an out-of-memory error can be inferred from a null pointer result
-    if (unsafeAddr dataLen).isNil:
-      let
-        code = sqlite3_errcode(sqlite3_db_handle(s))
-
-      raise (ref Defect)(msg: $sqlite3_errstr(code))
-
-    let
       dataBytes = cast[ptr UncheckedArray[byte]](blob)
 
     @(toOpenArray(dataBytes, 0, dataLen - 1))

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -97,7 +97,7 @@ const
     ) VALUES (?, ?, ?);
   """
 
-template checkColMetadata(s: RawStmtPtr, i: int, expectedName: string) =
+proc checkColMetadata(s: RawStmtPtr, i: int, expectedName: string) =
   let
     colName = sqlite3_column_origin_name(s, i.cint)
 

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -117,22 +117,7 @@ proc idCol*(
   checkColMetadata(s, index, idColName)
 
   return proc (): string =
-    let
-      text = sqlite3_column_text(s, index.cint)
-
-    # detect out-of-memory error
-    # see the conversion table and final paragraph of:
-    # https://www.sqlite.org/c3ref/column_blob.html
-
-    # the "id" column is NOT NULL PRIMARY KEY so an out-of-memory error can be
-    # inferred from a null pointer result
-    if text.isNil:
-      let
-        code = sqlite3_errcode(sqlite3_db_handle(s))
-
-      raise (ref Defect)(msg: $sqlite3_errstr(code))
-
-    $text.cstring
+    $sqlite3_column_text_not_null(s, index.cint)
 
 proc dataCol*(
   s: RawStmtPtr,

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -52,10 +52,6 @@ const
   dataColName = "data"
   timestampColName = "timestamp"
 
-  idColIndex = 0
-  dataColIndex = 1
-  timestampColIndex = 2
-
   idColType = "TEXT"
   dataColType = "BLOB"
   timestampColType = "INTEGER"
@@ -110,7 +106,7 @@ proc checkColMetadata(s: RawStmtPtr, i: int, expectedName: string) =
 
 proc idCol*(
   s: RawStmtPtr,
-  index = idColIndex): BoundIdCol =
+  index: int): BoundIdCol =
 
   checkColMetadata(s, index, idColName)
 
@@ -134,7 +130,7 @@ proc idCol*(
 
 proc dataCol*(
   s: RawStmtPtr,
-  index = dataColIndex): BoundDataCol =
+  index: int): BoundDataCol =
 
   checkColMetadata(s, index, dataColName)
 
@@ -175,7 +171,7 @@ proc dataCol*(
 
 proc timestampCol*(
   s: RawStmtPtr,
-  index = timestampColIndex): BoundTimestampCol =
+  index: int): BoundTimestampCol =
 
   checkColMetadata(s, index, timestampColName)
 

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -48,9 +48,9 @@ const
   dbExt* = ".sqlite3"
   tableName* = "Store"
 
-  idColName = "id"
-  dataColName = "data"
-  timestampColName = "timestamp"
+  idColName* = "id"
+  dataColName* = "data"
+  timestampColName* = "timestamp"
 
   idColType = "TEXT"
   dataColType = "BLOB"

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -67,6 +67,8 @@ const
     );
   """
 
+  containsStmtExistsCol = 0
+
   createStmtStr = """
     CREATE TABLE IF NOT EXISTS """ & tableName & """ (
       """ & idColName & """ """ & idColType & """ NOT NULL PRIMARY KEY,
@@ -84,6 +86,8 @@ const
     SELECT """ & dataColName & """ FROM """ & tableName & """
     WHERE """ & idColName & """ = ?;
   """
+
+  getStmtDataCol = 0
 
   putStmtStr = """
     REPLACE INTO """ & tableName & """ (
@@ -256,7 +260,7 @@ proc new*(
   # "SQL logic error"
 
   let
-    getDataCol = dataCol(RawStmtPtr(getStmt), 0)
+    getDataCol = dataCol(RawStmtPtr(getStmt), getStmtDataCol)
 
   success T(dbPath: dbPath, containsStmt: containsStmt, deleteStmt: deleteStmt,
             env: env.release, getStmt: getStmt, getDataCol: getDataCol,
@@ -290,7 +294,7 @@ method contains*(
     exists = false
 
   proc onData(s: RawStmtPtr) =
-    exists = sqlite3_column_int64(s, 0).bool
+    exists = sqlite3_column_int64(s, containsStmtExistsCol.cint).bool
 
   let
     queryRes = self.containsStmt.query((key.id), onData)

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -102,11 +102,13 @@ proc checkColMetadata(s: RawStmtPtr, i: int, expectedName: string) =
     colName = sqlite3_column_origin_name(s, i.cint)
 
   if colName.isNil:
-    raise (ref Defect)(msg: "no column exists for index " & $i)
+    raise (ref Defect)(msg: "no column exists for index " & $i & " in `" &
+      $sqlite3_sql(s) & "`")
 
   if $colName != expectedName:
     raise (ref Defect)(msg: "original column name for index " & $i & " was \"" &
-      $colName & "\" but expected \"" & expectedName & "\"")
+      $colName & "\" in `" & $sqlite3_sql(s) & "` but callee expected \"" &
+      expectedName & "\"")
 
 proc idCol*(
   s: RawStmtPtr,

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -105,9 +105,12 @@ proc idCol*(
     i = index.cint
     colName = sqlite3_column_origin_name(s, i)
 
-  if colName.isNil or $colName != idColName:
+  if colName.isNil:
+    raise (ref Defect)(msg: "no column exists for index " & $index)
+
+  if $colName != idColName:
     raise (ref Defect)(msg: "original column name for index " & $index &
-      " was not \"" & idColName & "\"")
+      " was \"" & $colName & "\" but expected \"" & idColName & "\"")
 
   return proc (): string =
     let
@@ -135,9 +138,12 @@ proc dataCol*(
     i = index.cint
     colName = sqlite3_column_origin_name(s, i)
 
-  if colName.isNil or $colName != dataColName:
+  if colName.isNil:
+    raise (ref Defect)(msg: "no column exists for index " & $index)
+
+  if $colName != dataColName:
     raise (ref Defect)(msg: "original column name for index " & $index &
-      " was not \"" & dataColName & "\"")
+      " was \"" & $colName & "\" but expected \"" & dataColName & "\"")
 
   return proc (): seq[byte] =
     let
@@ -181,9 +187,12 @@ proc timestampCol*(
     i = index.cint
     colName = sqlite3_column_origin_name(s, i)
 
-  if colName.isNil or $colName != timestampColName:
+  if colName.isNil:
+    raise (ref Defect)(msg: "no column exists for index " & $index)
+
+  if $colName != timestampColName:
     raise (ref Defect)(msg: "original column name for index " & $index &
-      " was not \"" & timestampColName & "\"")
+      " was \"" & $colName & "\" but expected \"" & timestampColName & "\"")
 
   return proc (): int64 =
     sqlite3_column_int64(s, i)

--- a/tests/datastore/test_sqlite_datastore.nim
+++ b/tests/datastore/test_sqlite_datastore.nim
@@ -137,7 +137,7 @@ suite "SQLiteDatastore":
 
     let
       prequeryRes = NoParamsStmt.prepare(
-        ds.env, "SELECT timestamp as foo, id as baz, data as bar FROM " &
+        ds.env, "SELECT timestamp AS foo, id AS baz, data AS bar FROM " &
           tableName & ";")
 
     assert prequeryRes.isOk


### PR DESCRIPTION
Check for out-of-memory errors re: usage of `sqlite3_column_text`, `sqlite3_column_blob`, `sqlite3_column_bytes`; raise a `Defect` if a SQLite out-of-memory error is encountered.

Closes #2.

---

Usage of the functions listed above is related to the helpers `idCol` and `dataCol`. Those procs can be made more resilient by checking column metadata with `sqlite3_column_origin_name()`.  Enabling that function involves passing `-DSQLITE_ENABLE_COLUMN_METADATA` to the C compiler, which is handled automatically in `datastore/sqlite.nim`.

The goal is to detect mismatches between caller-supplied indexes and original column names, and in that case crash the process by raising `Defect`. This should help avoid harder to debug errors for such mismatches, which would trigger automatic SQLite type conversions.

These helper procs (including `timestampCol`) are now higher-order, which allows column metadata checks to be run only once, i.e. when setting up derivative helpers to be used in an `onData` callback.

Related to changes to `idCol`, etc., use compile-time constants for column names and default indexes.

Also adjust callback proc annotations to be more precise, and remove unnecessary annotations.

---

Suppress overly verbose hints and warnings at compile-time by adding some switches to `config.nims`.