### PR TITLE
switch to `sqlite3_prepare_v3` and supply default `prepFlags`

### DIFF
--- a/datastore/sqlite.nim
+++ b/datastore/sqlite.nim
@@ -161,23 +161,27 @@ template open*(
 proc prepare*[Params, Res](
   T: type SQLiteStmt[Params, Res],
   env: SQLite,
-  stmt: string): ?!T =
+  stmt: string,
+  prepFlags: cuint = 0): ?!T =
 
   var
     s: RawStmtPtr
 
-  checkErr sqlite3_prepare_v2(env, stmt.cstring, stmt.len.cint, addr s, nil)
+  checkErr sqlite3_prepare_v3(
+    env, stmt.cstring, stmt.len.cint, prepFlags, addr s, nil)
 
   success T(s)
 
 template prepare*(
   env: SQLite,
-  q: string): RawStmtPtr =
+  q: string,
+  prepFlags: cuint = 0): RawStmtPtr =
 
   var
     s: RawStmtPtr
 
-  checkErr sqlite3_prepare_v2(env, q.cstring, q.len.cint, addr s, nil)
+  checkErr sqlite3_prepare_v3(
+    env, q.cstring, q.len.cint, prepFlags, addr s, nil)
 
   s
 

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -227,11 +227,17 @@ proc new*(
   if not readOnly:
     checkExec(env.val, createStmtStr)
 
-    deleteStmt = ? DeleteStmt.prepare(env.val, deleteStmtStr)
-    putStmt = ? PutStmt.prepare(env.val, putStmtStr)
+    deleteStmt = ? DeleteStmt.prepare(
+      env.val, deleteStmtStr, SQLITE_PREPARE_PERSISTENT)
 
-  containsStmt = ? ContainsStmt.prepare(env.val, containsStmtStr)
-  getStmt = ? GetStmt.prepare(env.val, getStmtStr)
+    putStmt = ? PutStmt.prepare(
+      env.val, putStmtStr, SQLITE_PREPARE_PERSISTENT)
+
+  containsStmt = ? ContainsStmt.prepare(
+    env.val, containsStmtStr, SQLITE_PREPARE_PERSISTENT)
+
+  getStmt = ? GetStmt.prepare(
+    env.val, getStmtStr, SQLITE_PREPARE_PERSISTENT)
 
   # if a readOnly/existing database does not satisfy the expected schema
   # `pepare()` will fail and `new` will return an error with message


### PR DESCRIPTION
For long-lived prepared statements in `datastore/sqlite_datastore.nim` use `prepFlags = SQLITE_PREPARE_PERSISTENT`.

Closes #13.