### PR TITLE
add basic query implementation

### DIFF
--- a/datastore/datastore.nim
+++ b/datastore/datastore.nim
@@ -4,8 +4,9 @@ import pkg/questionable/results
 import pkg/upraises
 
 import ./key
+import ./query
 
-export key
+export key, query
 
 push: {.upraises: [].}
 
@@ -37,8 +38,8 @@ method put*(
 
   raiseAssert("Not implemented!")
 
-# method query*(
-#   self: Datastore,
-#   query: ...): Future[?!(?...)] {.async, base, locks: "unknown".} =
-#
-#   raiseAssert("Not implemented!")
+iterator query*(
+  self: Datastore,
+  query: Query): Future[QueryResponse] =
+
+  raiseAssert("Not implemented!")

--- a/datastore/key.nim
+++ b/datastore/key.nim
@@ -211,7 +211,7 @@ template `[]`*(
 proc len*(self: Key): int =
   self.namespaces.len
 
-iterator items*(key: Key): Namespace {.inline.} =
+iterator items*(key: Key): Namespace =
   var
     i = 0
 

--- a/datastore/null_datastore.nim
+++ b/datastore/null_datastore.nim
@@ -40,8 +40,8 @@ method put*(
 
   return success()
 
-# method query*(
-#   self: NullDatastore,
-#   query: ...): Future[?!(?...)] {.async, locks: "unknown".} =
-#
-#   return success ....none
+iterator query*(
+  self: NullDatastore,
+  query: Query): Future[QueryResponse] =
+
+  discard

--- a/datastore/query.nim
+++ b/datastore/query.nim
@@ -1,0 +1,18 @@
+import ./key
+
+type
+  Query* = object
+    key: QueryKey
+
+  QueryKey* = Key
+
+  QueryResponse* = tuple[key: Key, data: seq[byte]]
+
+proc init*(
+  T: type Query,
+  key: QueryKey): T =
+
+  T(key: key)
+
+proc key*(self: Query): QueryKey =
+  self.key

--- a/datastore/sqlite.nim
+++ b/datastore/sqlite.nim
@@ -30,6 +30,13 @@ type
 
   SQLiteStmt*[Params, Res] = distinct RawStmtPtr
 
+  # see https://github.com/arnetheduck/nim-sqlite3-abi/issues/4
+  sqlite3_destructor_type_gcsafe =
+    proc (a1: pointer) {.cdecl, gcsafe, upraises: [].}
+
+const
+  SQLITE_TRANSIENT_GCSAFE* = cast[sqlite3_destructor_type_gcsafe](-1)
+
 proc bindParam(
   s: RawStmtPtr,
   n: int,
@@ -248,8 +255,8 @@ proc sqlite3_column_text_not_null*(
     # https://www.sqlite.org/c3ref/column_blob.html
     # a null pointer here implies an out-of-memory error
     let
-      code = sqlite3_errcode(sqlite3_db_handle(s))
+      v = sqlite3_errcode(sqlite3_db_handle(s))
 
-    raise (ref Defect)(msg: $sqlite3_errstr(code))
+    raise (ref Defect)(msg: $sqlite3_errstr(v))
 
   text

--- a/tests/datastore/test_datastore.nim
+++ b/tests/datastore/test_datastore.nim
@@ -11,10 +11,9 @@ suite "Datastore (base)":
   let
     key = Key.init("a").get
     ds = Datastore()
-    oneByte = @[1.byte]
 
   asyncTest "put":
-    expect Defect: discard ds.put(key, oneByte)
+    expect Defect: discard ds.put(key, @[1.byte])
 
   asyncTest "delete":
     expect Defect: discard ds.delete(key)
@@ -25,5 +24,6 @@ suite "Datastore (base)":
   asyncTest "get":
     expect Defect: discard ds.get(key)
 
-  # asyncTest "query":
-  #   expect Defect: discard ds.query(...)
+  asyncTest "query":
+    expect Defect:
+      for n in ds.query(Query.init(key)): discard

--- a/tests/datastore/test_null_datastore.nim
+++ b/tests/datastore/test_null_datastore.nim
@@ -31,7 +31,14 @@ suite "NullDatastore":
       (await ds.get(key)).isOk
       (await ds.get(key)).get.isNone
 
-  # asyncTest "query":
-  #   check:
-  #     (await ds.query(...)).isOk
-  #     (await ds.query(...)).get.isNone
+  asyncTest "query":
+    var
+      x = true
+
+    for n in ds.query(Query.init(key)):
+      # `iterator query` for NullDatastore never yields so the following lines
+      # are not run (else the test would hang)
+      x = false
+      discard (await n)
+
+    check: x

--- a/tests/datastore/test_sqlite_datastore.nim
+++ b/tests/datastore/test_sqlite_datastore.nim
@@ -1,3 +1,4 @@
+import std/algorithm
 import std/options
 import std/os
 
@@ -331,6 +332,261 @@ suite "SQLiteDatastore":
 
     check: getOpt.isNone
 
-  # asyncTest "query":
-  #   check:
-  #     true
+  asyncTest "query":
+    ds = SQLiteDatastore.new(basePathAbs, filename).get
+
+    var
+      key1 = Key.init("a").get
+      key2 = Key.init("a/b").get
+      key3 = Key.init("a/b:c").get
+      key4 = Key.init("a:b").get
+      key5 = Key.init("a:b/c").get
+      key6 = Key.init("a:b/c:d").get
+      key7 = Key.init("A").get
+      key8 = Key.init("A/B").get
+      key9 = Key.init("A/B:C").get
+      key10 = Key.init("A:B").get
+      key11 = Key.init("A:B/C").get
+      key12 = Key.init("A:B/C:D").get
+
+      bytes1  = @[1.byte, 2.byte, 3.byte]
+      bytes2  = @[4.byte, 5.byte, 6.byte]
+      bytes3: seq[byte] = @[]
+      bytes4  = bytes1
+      bytes5  = bytes2
+      bytes6  = bytes3
+      bytes7  = bytes1
+      bytes8  = bytes2
+      bytes9  = bytes3
+      bytes10  = bytes1
+      bytes11  = bytes2
+      bytes12  = bytes3
+
+      queryKey = Key.init("*").get
+
+    var
+      putRes = await ds.put(key1, bytes1)
+
+    assert putRes.isOk
+    putRes = await ds.put(key2, bytes2)
+    assert putRes.isOk
+    putRes = await ds.put(key3, bytes3)
+    assert putRes.isOk
+    putRes = await ds.put(key4, bytes4)
+    assert putRes.isOk
+    putRes = await ds.put(key5, bytes5)
+    assert putRes.isOk
+    putRes = await ds.put(key6, bytes6)
+    assert putRes.isOk
+    putRes = await ds.put(key7, bytes7)
+    assert putRes.isOk
+    putRes = await ds.put(key8, bytes8)
+    assert putRes.isOk
+    putRes = await ds.put(key9, bytes9)
+    assert putRes.isOk
+    putRes = await ds.put(key10, bytes10)
+    assert putRes.isOk
+    putRes = await ds.put(key11, bytes11)
+    assert putRes.isOk
+    putRes = await ds.put(key12, bytes12)
+    assert putRes.isOk
+
+    var
+      kds: seq[QueryResponse]
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    # see https://sqlite.org/lang_select.html#the_order_by_clause
+    # If a SELECT statement that returns more than one row does not have an
+    # ORDER BY clause, the order in which the rows are returned is undefined.
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key1, data: bytes1),
+      (key: key2, data: bytes2),
+      (key: key3, data: bytes3),
+      (key: key4, data: bytes4),
+      (key: key5, data: bytes5),
+      (key: key6, data: bytes6),
+      (key: key7, data: bytes7),
+      (key: key8, data: bytes8),
+      (key: key9, data: bytes9),
+      (key: key10, data: bytes10),
+      (key: key11, data: bytes11),
+      (key: key12, data: bytes12)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    queryKey = Key.init("a*").get
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key1, data: bytes1),
+      (key: key2, data: bytes2),
+      (key: key3, data: bytes3),
+      (key: key4, data: bytes4),
+      (key: key5, data: bytes5),
+      (key: key6, data: bytes6)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    queryKey = Key.init("A*").get
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key7, data: bytes7),
+      (key: key8, data: bytes8),
+      (key: key9, data: bytes9),
+      (key: key10, data: bytes10),
+      (key: key11, data: bytes11),
+      (key: key12, data: bytes12)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    queryKey = Key.init("a/?").get
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key2, data: bytes2)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    queryKey = Key.init("A/?").get
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key8, data: bytes8)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    queryKey = Key.init("*/?").get
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key2, data: bytes2),
+      (key: key5, data: bytes5),
+      (key: key8, data: bytes8),
+      (key: key11, data: bytes11)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    queryKey = Key.init("[Aa]/?").get
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key2, data: bytes2),
+      (key: key8, data: bytes8)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    # SQLite's GLOB operator, akin to Unix file globbing syntax, is greedy re:
+    # wildcard "*". So a pattern such as "a:*[^/]" will not restrict results to
+    # "/a:b", i.e. it will match on "/a:b", "/a:b/c" and "/a:b/c:d".
+
+    queryKey = Key.init("a:*[^/]").get
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key4, data: bytes4),
+      (key: key5, data: bytes5),
+      (key: key6, data: bytes6)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    queryKey = Key.init("a:*[Bb]").get
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds.sortedByIt(it.key.id) == @[
+      (key: key4, data: bytes4)
+    ].sortedByIt(it.key.id)
+
+    kds = @[]
+
+    var
+      deleteRes = await ds.delete(key1)
+
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key2)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key3)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key4)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key5)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key6)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key7)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key8)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key9)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key10)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key11)
+    assert deleteRes.isOk
+    deleteRes = await ds.delete(key12)
+    assert deleteRes.isOk
+
+    let
+      emptyKds: seq[QueryResponse] = @[]
+
+    for kd in ds.query(Query.init(queryKey)):
+      let
+        (key, data) = await kd
+
+      kds.add (key, data)
+
+    check: kds == emptyKds


### PR DESCRIPTION
This PR adds a basic `query` implementation for base `Datastore`, `NullDatastore`, and most importantly `SQLiteDatastore`.

Closes #8.

An implementation for `FileSystemDatastore` will be skipped at this time, though it can be revisited in the future.

The immediate use case for this facility is https://github.com/status-im/nim-codex/issues/138, it's also relevant to https://github.com/status-im/nim-codex/issues/131.

For https://github.com/status-im/nim-codex/issues/137, if we want to use `TieredDatastore`, then some decisions need to made re: the desired behavior, as explained below.

**General Notes**

The first choice was *how* to implement the facility: should it be `method query` or `iterator query`? The second choice was whether it should be sync or async.

A `method query` approach would naturally involve `return`ing `seq[(key, data)]` (entire results for the query), while `iterator query` would involve `yield`ing `(key, data)` one at a time.

I chose to proceed with `iterator query` and made it async:

```nim
type
  QueryResponse* = tuple[key: Key, data: seq[byte]]

iterator query*(self: SQLiteDatastore, query: Query): Future[QueryResponse] =
  ...
```

Note that this is presently *"faux async"* just like `method get`, etc.

**Types `Query` and `QueryKey`**

The original vision of Python Datastore (embraced by various implementations in JavaScript and Go) is to have a `Query` class/object that provides a high-level almost declarative API for specifying what to query, how to filter, sort, and so on.

The basic implementation in this PR does **not** attempt to fulfill that vision. Rather, a `Query` object is constructed only with a `QueryKey`, and at the moment `QueryKey` is simply an alias for `Key`.

In the case of `SQLiteDatastore`, the idea is that a `QueryKey` will use the [`GLOB`](https://sqlite.org/lang_expr.html#glob) syntax supported by SQLite to match multiple rows.

Imagine that a Codex manifest with CID `abcd1234` is stored with key `manifest:abcd1234`. To retrieve all the blocks stored for that manifest, one could do something like:

```nim
for block in ds.query(Query.init("manifest:abcd1234/block:*")):
  let
    # key will look like "manifest:abcd1234/block:[cid]"
    (key, data) = await block
    
  ...
```

**Limitations of SQLite GLOB**

SQLite's GLOB syntax is *not* a form of regular expressions. The wildcard `*` is greedy such that the following won't work re: querying for all the manifests but not their blocks (per hypothetical example above):

```nim
ds.query(Query.init("manifest:*[^/]"))
```

That would match all manifests *and* all their blocks.

If desirable, there are a number of ways to work around that at the application level (i.e. in a program using `SQLiteDatastore`), or we could consider enabling PCRE support in SQLite and using `REGEXP` instead of `GLOB` for the `QueryKey` parameter.

**Async + Iterator**

Consider the support built into the JavaScript language for asynchronous iteration:
* [`Symbol.asyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)
* [`for-await...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)
* [`async function*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*)

Those language constructs work together so that async iteration is well-defined and distinct from sync iteration. For example, `for-await...of` needs to be used in the general case of async iteration because it's not generally possible to know in advance how many times an async iterable will yield a value. In other words, you can't use `Promise.all()`, you need to step through each promised value, awaiting each in turn. Or you can use some sugar lib like [IxJS](https://github.com/ReactiveX/IxJS#readme) to avoid manually writing `for-await...of` loops.

We don't currently have libs or lang features for Nim that are dedicated to async iteration. So, it's important to understand that it will be up to the caller to `await` on each step in a loop over async `iterator query`, at least in the general case, i.e. instead of trying to collect all the responses into chronos' `allFinished()`.

Because `iterator query` for `SQLiteDatastore` is *"faux async"*, it technically could work to exhaust the iterator and run the collected `Future`s through `allFinished()`. But when we move to a case like `TieredDatastore` (depending on how that works), or when we have a multi-threaded solution where the actual querying of the database takes place on a worker thread, then it's not feasible to do that, at least not without additional machinery.

**TieredDatastore**

In the original Python Datastore, there is this [doc comment](https://github.com/datastore/datastore/blob/7ccf0cd4748001d3dbf5e6dda369b0f63e0269d3/datastore/core/basic.py#L1027-L1028) for `class TieredDatastore`:
```
Datastores should be arranged in order of completeness,
with the most complete datastore last, as it will handle query calls.
```
And below that:
```python
def query(self, query):
    '''Returns a sequence of objects matching criteria expressed in `query`.
    The last datastore will handle all query calls, as it has a (if not
    the only) complete record of all objects.
    '''
    # queries hit the last (most complete) datastore
    return self._stores[-1].query(query)
```
Indeed, it's not clear how a `query` implementation (in Nim, Python, or other lang) should operate internally if a query op were to span multiple stores.

So `iterator query` for nim-datastore's `TieredDatastore` should probably have the last datastore directly handle queries.

However, that does not mean that application-specific derivatives of `TieredDatastore` could not have specialized logic for e.g. `method get` vs. `iterator query`.

Codex, for example, might have this arrangement re: nim-datastore layers in a derivative of `TieredDatastore`:
```
LRU cache -> SQLite -> Network
```
While `method get` may attempt to resolve a key from `Network` if neither `LRU cache` nor `SQLite` has it, `iterator query` could bypass `LRU cache` and go directly to `SQlite` while also *not* attempting to fall through to `Network`.

**TODO in future PRs**

We could prevent GLOB characters (`*`, `?`, `[`, `]`) from being used in strings passed to `Key.init()` while allowing them to be used in `QueryKey.init()`.

In #11 we look toward a refactor that will be generic with respect to parameters and return types. That will provide additional flexibility, allowing concrete implementations to diverge in terms of their choice of base `Key` and other base types, how e.g. `Key` relates to `Query` and `QueryKey` (and even data layout in the backend), and making it simpler for applications to specialize on types and behaviors for `get`, `query`, etc. for a specific backend on which they choose to build.