### PR TITLE
introduce methods close and query in the base API and refactor accordingly

### DIFF
--- a/datastore/datastore.nim
+++ b/datastore/datastore.nim
@@ -13,6 +13,10 @@ push: {.upraises: [].}
 type
   Datastore* = ref object of RootObj
 
+  QueryIterator* = iterator (
+    datastore: Datastore,
+    query: Query): Future[QueryResponse] {.closure, gcsafe.}
+
 method close*(self: Datastore): Future[void] {.base, locks: "unknown".} =
   raiseAssert("Not implemented!")
 
@@ -41,8 +45,5 @@ method put*(
 
   raiseAssert("Not implemented!")
 
-iterator query*(
-  self: Datastore,
-  query: Query): Future[QueryResponse] =
-
+method query*(self: Datastore): QueryIterator {.base, locks: "unknown".} =
   raiseAssert("Not implemented!")

--- a/datastore/datastore.nim
+++ b/datastore/datastore.nim
@@ -13,28 +13,31 @@ push: {.upraises: [].}
 type
   Datastore* = ref object of RootObj
 
+method close*(self: Datastore): Future[void] {.base, locks: "unknown".} =
+  raiseAssert("Not implemented!")
+
 method contains*(
   self: Datastore,
-  key: Key): Future[?!bool] {.async, base, locks: "unknown".} =
+  key: Key): Future[?!bool] {.base, locks: "unknown".} =
 
   raiseAssert("Not implemented!")
 
 method delete*(
   self: Datastore,
-  key: Key): Future[?!void] {.async, base, locks: "unknown".} =
+  key: Key): Future[?!void] {.base, locks: "unknown".} =
 
   raiseAssert("Not implemented!")
 
 method get*(
   self: Datastore,
-  key: Key): Future[?!(?seq[byte])] {.async, base, locks: "unknown".} =
+  key: Key): Future[?!(?seq[byte])] {.base, locks: "unknown".} =
 
   raiseAssert("Not implemented!")
 
 method put*(
   self: Datastore,
   key: Key,
-  data: seq[byte]): Future[?!void] {.async, base, locks: "unknown".} =
+  data: seq[byte]): Future[?!void] {.base, locks: "unknown".} =
 
   raiseAssert("Not implemented!")
 

--- a/datastore/filesystem_datastore.nim
+++ b/datastore/filesystem_datastore.nim
@@ -59,6 +59,9 @@ proc path*(
 
   self.root / joinPath(segments) & objExt
 
+method close*(self: FileSystemDatastore) {.async, locks: "unknown".} =
+  discard
+
 method contains*(
   self: FileSystemDatastore,
   key: Key): Future[?!bool] {.async, locks: "unknown".} =

--- a/datastore/filesystem_datastore.nim
+++ b/datastore/filesystem_datastore.nim
@@ -157,9 +157,3 @@ method put*(
 
   except OSError as e:
     return failure e
-
-# method query*(
-#   self: FileSystemDatastore,
-#   query: ...): Future[?!(?...)] {.async, locks: "unknown".} =
-#
-#   return success ....some

--- a/datastore/null_datastore.nim
+++ b/datastore/null_datastore.nim
@@ -15,6 +15,9 @@ type
 proc new*(T: type NullDatastore): T =
   T()
 
+method close*(self: NullDatastore) {.async, locks: "unknown".} =
+  discard
+
 method contains*(
   self: NullDatastore,
   key: Key): Future[?!bool] {.async, locks: "unknown".} =

--- a/datastore/null_datastore.nim
+++ b/datastore/null_datastore.nim
@@ -43,8 +43,11 @@ method put*(
 
   return success()
 
-iterator query*(
-  self: NullDatastore,
-  query: Query): Future[QueryResponse] =
+iterator queryImpl(
+  datastore: Datastore,
+  query: Query): Future[QueryResponse] {.closure.} =
 
   discard
+
+method query*(self: NullDatastore): QueryIterator {.locks: "unknown".} =
+  queryImpl

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -367,13 +367,14 @@ method put*(
 
   return await self.put(key, data, timestamp())
 
-iterator query*(
-  self: SQLiteDatastore,
-  query: Query): Future[QueryResponse] =
+iterator queryImpl(
+  datastore: Datastore,
+  query: Query): Future[QueryResponse] {.closure.} =
 
   let
+    datastore = SQLiteDatastore(datastore)
     queryStmt = QueryStmt.prepare(
-      self.env, queryStmtStr).expect("should not fail")
+      datastore.env, queryStmtStr).expect("should not fail")
 
     s = RawStmtPtr(queryStmt)
 
@@ -428,3 +429,6 @@ iterator query*(
       break
     else:
       raise (ref Defect)(msg: $sqlite3_errstr(v))
+
+method query*(self: SQLiteDatastore): QueryIterator {.locks: "unknown".} =
+  queryImpl

--- a/datastore/sqlite_datastore.nim
+++ b/datastore/sqlite_datastore.nim
@@ -284,7 +284,10 @@ proc dbPath*(self: SQLiteDatastore): string =
 proc env*(self: SQLiteDatastore): SQLite =
   self.env
 
-proc close*(self: SQLiteDatastore) =
+proc timestamp*(t = epochTime()): int64 =
+  (t * 1_000_000).int64
+
+method close*(self: SQLiteDatastore) {.async, locks: "unknown".} =
   self.containsStmt.dispose
   self.getStmt.dispose
 
@@ -294,9 +297,6 @@ proc close*(self: SQLiteDatastore) =
 
   self.env.dispose
   self[] = SQLiteDatastore()[]
-
-proc timestamp*(t = epochTime()): int64 =
-  (t * 1_000_000).int64
 
 method contains*(
   self: SQLiteDatastore,

--- a/datastore/tiered_datastore.nim
+++ b/datastore/tiered_datastore.nim
@@ -28,6 +28,10 @@ proc new*(
 proc stores*(self: TieredDatastore): seq[Datastore] =
   self.stores
 
+method close*(self: TieredDatastore) {.async, locks: "unknown".} =
+  for store in self.stores:
+    await store.close
+
 method contains*(
   self: TieredDatastore,
   key: Key): Future[?!bool] {.async, locks: "unknown".} =

--- a/tests/datastore/test_datastore.nim
+++ b/tests/datastore/test_datastore.nim
@@ -25,5 +25,4 @@ suite "Datastore (base)":
     expect Defect: discard ds.get(key)
 
   asyncTest "query":
-    expect Defect:
-      for n in ds.query(Query.init(key)): discard
+    expect Defect: discard ds.query

--- a/tests/datastore/test_filesystem_datastore.nim
+++ b/tests/datastore/test_filesystem_datastore.nim
@@ -190,7 +190,3 @@ suite "FileSystemDatastore":
     getOpt = getRes.get
 
     check: getOpt.isNone
-
-  # asyncTest "query":
-  #   check:
-  #     true

--- a/tests/datastore/test_null_datastore.nim
+++ b/tests/datastore/test_null_datastore.nim
@@ -35,7 +35,7 @@ suite "NullDatastore":
     var
       x = true
 
-    for n in ds.query(Query.init(key)):
+    let q = ds.query; for n in q(ds, Query.init(key)):
       # `iterator query` for NullDatastore never yields so the following lines
       # are not run (else the test would hang)
       x = false

--- a/tests/datastore/test_sqlite_datastore.nim
+++ b/tests/datastore/test_sqlite_datastore.nim
@@ -26,7 +26,7 @@ suite "SQLiteDatastore":
     createDir(basePathAbs)
 
   teardown:
-    if not ds.isNil: ds.close
+    if not ds.isNil: await ds.close
     ds = nil
     removeDir(basePathAbs)
     require(not dirExists(basePathAbs))
@@ -49,7 +49,7 @@ suite "SQLiteDatastore":
       dsRes.isOk
       fileExists(dbPathAbs)
 
-    dsRes.get.close
+    await dsRes.get.close
     removeDir(basePathAbs)
     assert not dirExists(basePathAbs)
     createDir(basePathAbs)
@@ -60,7 +60,7 @@ suite "SQLiteDatastore":
       dsRes.isOk
       fileExists(dbPathAbs)
 
-    dsRes.get.close
+    await dsRes.get.close
 
     # for `readOnly = true` to succeed the database file must already exist, so
     # the existing file (per previous step) is not deleted prior to the next
@@ -70,7 +70,7 @@ suite "SQLiteDatastore":
 
     check: dsRes.isOk
 
-    dsRes.get.close
+    await dsRes.get.close
     removeDir(basePathAbs)
     assert not dirExists(basePathAbs)
     createDir(basePathAbs)
@@ -79,7 +79,7 @@ suite "SQLiteDatastore":
 
     check: dsRes.isOk
 
-    dsRes.get.close
+    await dsRes.get.close
 
     dsRes = SQLiteDatastore.new(memory, readOnly = true)
 
@@ -95,7 +95,7 @@ suite "SQLiteDatastore":
   asyncTest "helpers":
     ds = SQLiteDatastore.new(basePath).get
 
-    ds.close
+    await ds.close
 
     check:
       ds.env.isNil
@@ -107,7 +107,7 @@ suite "SQLiteDatastore":
 
     # for `readOnly = true` to succeed the database file must already exist
     ds = SQLiteDatastore.new(basePathAbs, filename).get
-    ds.close
+    await ds.close
     ds = SQLiteDatastore.new(basePathAbs, filename, readOnly = true).get
 
     var
@@ -117,7 +117,7 @@ suite "SQLiteDatastore":
 
     check: putRes.isErr
 
-    ds.close
+    await ds.close
     removeDir(basePathAbs)
     assert not dirExists(basePathAbs)
     createDir(basePathAbs)
@@ -211,7 +211,7 @@ suite "SQLiteDatastore":
 
     # for `readOnly = true` to succeed the database file must already exist
     ds = SQLiteDatastore.new(basePathAbs, filename).get
-    ds.close
+    await ds.close
     ds = SQLiteDatastore.new(basePathAbs, filename, readOnly = true).get
 
     var
@@ -219,7 +219,7 @@ suite "SQLiteDatastore":
 
     check: delRes.isErr
 
-    ds.close
+    await ds.close
     removeDir(basePathAbs)
     assert not dirExists(basePathAbs)
     createDir(basePathAbs)

--- a/tests/datastore/test_sqlite_datastore.nim
+++ b/tests/datastore/test_sqlite_datastore.nim
@@ -387,19 +387,19 @@ suite "SQLiteDatastore":
     assert putRes.isOk
 
     var
-      kds: seq[QueryResponse]
+      kvs: seq[QueryResponse]
 
-    for kd in ds.query(Query.init(queryKey)):
+    var q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (rkey, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (rkey, data)
 
     # see https://sqlite.org/lang_select.html#the_order_by_clause
     # If a SELECT statement that returns more than one row does not have an
     # ORDER BY clause, the order in which the rows are returned is undefined.
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key1, data: bytes1),
       (key: key2, data: bytes2),
       (key: key3, data: bytes3),
@@ -414,17 +414,17 @@ suite "SQLiteDatastore":
       (key: key12, data: bytes12)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     queryKey = Key.init("a*").get
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (rkey, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (rkey, data)
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key1, data: bytes1),
       (key: key2, data: bytes2),
       (key: key3, data: bytes3),
@@ -433,17 +433,17 @@ suite "SQLiteDatastore":
       (key: key6, data: bytes6)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     queryKey = Key.init("A*").get
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (rkey, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (rkey, data)
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key7, data: bytes7),
       (key: key8, data: bytes8),
       (key: key9, data: bytes9),
@@ -452,67 +452,67 @@ suite "SQLiteDatastore":
       (key: key12, data: bytes12)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     queryKey = Key.init("a/?").get
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (rkey, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (rkey, data)
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key2, data: bytes2)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     queryKey = Key.init("A/?").get
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (rkey, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (rkey, data)
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key8, data: bytes8)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     queryKey = Key.init("*/?").get
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (rkey, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (rkey, data)
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key2, data: bytes2),
       (key: key5, data: bytes5),
       (key: key8, data: bytes8),
       (key: key11, data: bytes11)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     queryKey = Key.init("[Aa]/?").get
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (key, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (key, data)
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key2, data: bytes2),
       (key: key8, data: bytes8)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     # SQLite's GLOB operator, akin to Unix file globbing syntax, is greedy re:
     # wildcard "*". So a pattern such as "a:*[^/]" will not restrict results to
@@ -520,33 +520,33 @@ suite "SQLiteDatastore":
 
     queryKey = Key.init("a:*[^/]").get
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (key, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (key, data)
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key4, data: bytes4),
       (key: key5, data: bytes5),
       (key: key6, data: bytes6)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     queryKey = Key.init("a:*[Bb]").get
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (key, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (key, data)
 
-    check: kds.sortedByIt(it.key.id) == @[
+    check: kvs.sortedByIt(it.key.id) == @[
       (key: key4, data: bytes4)
     ].sortedByIt(it.key.id)
 
-    kds = @[]
+    kvs = @[]
 
     var
       deleteRes = await ds.delete(key1)
@@ -576,12 +576,12 @@ suite "SQLiteDatastore":
     assert deleteRes.isOk
 
     let
-      emptyKds: seq[QueryResponse] = @[]
+      emptyKvs: seq[QueryResponse] = @[]
 
-    for kd in ds.query(Query.init(queryKey)):
+    q = ds.query; for kv in q(ds, Query.init(queryKey)):
       let
-        (key, data) = await kd
+        (key, data) = await kv
 
-      kds.add (key, data)
+      kvs.add (key, data)
 
-    check: kds == emptyKds
+    check: kvs == emptyKvs

--- a/tests/datastore/test_tiered_datastore.nim
+++ b/tests/datastore/test_tiered_datastore.nim
@@ -30,7 +30,7 @@ suite "TieredDatastore":
     ds2 = FileSystemDatastore.new(rootAbs).get
 
   teardown:
-    if not ds1.isNil: ds1.close
+    if not ds1.isNil: await ds1.close
     ds1 = nil
     removeDir(rootAbs)
     require(not dirExists(rootAbs))
@@ -132,7 +132,7 @@ suite "TieredDatastore":
       (await ds1.get(key)).get.get == bytes
       (await ds2.get(key)).get.get == bytes
 
-    ds1.close
+    await ds1.close
     ds1 = SQLiteDatastore.new(memory).get
     ds = TieredDatastore.new(ds1, ds2).get
 


### PR DESCRIPTION
The goal of this PR is to make `Datastore` and derived types more flexible, e.g. in nim-libp2p-dht we want to specify `providers: Datastore` instead of `providers: SQLiteDatastore` and have the freedom to choose one implementation or another without having to change the type definition (see https://github.com/status-im/nim-libp2p-dht/pull/41#discussion_r966316669).

`method close` is introduced in a similar manner as was done for `BlockStore` in https://github.com/status-im/nim-codex/pull/160.

`method query` required a bit more experimentation, but the end result seems viable. The challenge is that Nim's `iterator` does not support the dynamic dispatch of `method`. However, we can specify a single return type (see `type QueryImpl` in this PR) for implementations of `method query`, and then in the returned `queryImpl` iterator use object conversion to get back to the correct specific type derived from `Datastore`.

I did a small amount of additional cleanup, e.g. it's not necessary to specify the `async` pragma in base methods of `Datastore`.

In the tests for `SQLiteDatastore`, in some places I had to change the name of a variable `key` to something else (I chose `rkey`) otherwise I was getting compile-time errors from clang/gcc:
```
CC: datastore/test_sqlite_datastore.nim
/path/to/.cache/nim/test_all_d/@mdatastore@stest_sqlite_datastore.nim.c:1087:39: error: duplicate member 'key89'
tyObject_Key__6b3P9aUji2WzyTKPwAJWNUQ key89;
                                      ^
/path/to/.cache/nim/test_all_d/@mdatastore@stest_sqlite_datastore.nim.c:1007:39: note: previous declaration is here
tyObject_Key__6b3P9aUji2WzyTKPwAJWNUQ key89;
                                      ^
1 error generated.
Error: execution of an external compiler program 'clang -c  -w -ferror-limit=3 -pthread -DSQLITE_ENABLE_COLUMN_METADATA   -I'/path/to/.choosenim/toolchains/nim-#devel/lib' -I/path/to/repos/nim-datastore/tests -o /path/to/.cache/nim/test_all_d/@mdatastore@stest_sqlite_datastore.nim.c.o /path/to/.cache/nim/test_all_d/@mdatastore@stest_sqlite_datastore.nim.c' failed with exit code: 1
```
I've seen similar previously, I believe it's owing to a bug/limitation in Nim's compiler.

---

Closes #28.