### PR TITLE
Threadpool semaphore ref ctx type

### DIFF
--- a/datastore/threads/threadproxyds.nim
+++ b/datastore/threads/threadproxyds.nim
@@ -35,12 +35,12 @@ type
   ThreadResult[T: ThreadTypes] = Result[T, DataBuffer]
 
   TaskCtx[T: ThreadTypes] = ref object
-    ds: ptr Datastore
-    res: ThreadResult[T]
+    ds*: ptr Datastore
+    res*: ThreadResult[T]
     cancelled: Atomic[bool]
     isActive: Atomic[bool]
     semaphore: AsyncSemaphore
-    signal: ThreadSignalPtr
+    signal*: ThreadSignalPtr
 
   ThreadDatastore* = ref object of Datastore
     tp: Taskpool

--- a/datastore/threads/threadproxyds.nim
+++ b/datastore/threads/threadproxyds.nim
@@ -62,8 +62,8 @@ proc new*[T](
     ds: Datastore,
 ): ref TaskCtx[T] =
   result = (ref TaskCtx[T])()
-  result.ds = unsafeAddr(ds) ## 
-    ## doing this appears to break. previously it was using `addr(ds)`
+  result.ds = unsafeAddr(ds) ##\
+    ## doing this appears to break things. previously it was using `addr(ds)`
     ## and reverting to those lets the tests get further. 
     ## 
     ## however, that seems to mean that `addr(ds)` we're taking the 

--- a/datastore/threads/threadproxyds.nim
+++ b/datastore/threads/threadproxyds.nim
@@ -74,6 +74,9 @@ proc new*[T](
     ## of the `ds` argument, which is a temporary stack location.
     ## 
     ## not sure how to fix this while using GC types
+    ## just taking the address of the var location sorta works, but
+    ## crashes now as well, but later. likely due to datastore now being
+    ## on two GC heaps?
 
   echo ""
   echo "TaskCtx:new: ", "addrOf: ", addrOf(result).pointer.repr

--- a/datastore/threads/threadproxyds.nim
+++ b/datastore/threads/threadproxyds.nim
@@ -137,6 +137,7 @@ template dispatchTask(
       # could do a spinlock here until the other side cancels,
       # but for now it'd at least be better to leak than possibly
       # corrupt memory since it's easier to detect and fix leaks
+      # and they won't corrupt random bits of memory
       warn "request was cancelled while thread task is running", exc = exc.msg
       GC_ref(ctx)
     ctx.cancelled.store(true, moAcquireRelease)

--- a/datastore/threads/threadproxyds.nim
+++ b/datastore/threads/threadproxyds.nim
@@ -53,7 +53,8 @@ type
                               # needed for the fsds, but it is expensive!
 
 proc addrOf*[T](ctx: ref TaskCtx[T]): ptr TaskCtx[T] =
-  cast[ptr TaskCtx[T]](ctx)
+  result = cast[ptr TaskCtx[T]](ctx)
+  echo "ADDR_OF: ", result.pointer.repr
 
 proc new*[T](
     ctx: typedesc[TaskCtx[T]],

--- a/datastore/threads/threadproxyds.nim
+++ b/datastore/threads/threadproxyds.nim
@@ -235,6 +235,8 @@ proc asyncPutTask(
   key: ptr Key,
   data: ptr UncheckedArray[byte],
   len: int) {.async.} =
+
+  echo "PUT TASK: ", ctx.repr
   defer:
     discard ctx[].signal.fireSync()
 

--- a/tests/datastore/testthreadproxyds.nim
+++ b/tests/datastore/testthreadproxyds.nim
@@ -146,13 +146,11 @@ suite "Test ThreadDatastore cancelations":
   test "Should monitor signal and cancel":
     var
       signal = ThreadSignalPtr.new().tryGet()
-      res = ThreadResult[void]()
       ctx = TaskCtx[void](
         ds: addr sqlStore,
-        res: addr res,
         signal: signal)
       fut = newFuture[void]("signalMonitor")
-      threadArgs = (addr ctx, addr fut)
+      threadArgs: (ptr TaskCtx, ptr Future[void]) = (unsafeAddr ctx[], addr fut)
 
     var
       thread: Thread[type threadArgs]

--- a/tests/datastore/testthreadproxyds.nim
+++ b/tests/datastore/testthreadproxyds.nim
@@ -150,7 +150,7 @@ suite "Test ThreadDatastore cancelations":
         ds: addr sqlStore,
         signal: signal)
       fut = newFuture[void]("signalMonitor")
-      threadArgs: (ptr TaskCtx, ptr Future[void]) = (unsafeAddr ctx[], addr fut)
+      threadArgs = (cast[ptr TaskCtx[void]](ctx), addr fut)
 
     var
       thread: Thread[type threadArgs]

--- a/tests/datastore/testthreadproxyds.nim
+++ b/tests/datastore/testthreadproxyds.nim
@@ -147,9 +147,7 @@ suite "Test ThreadDatastore cancelations":
   test "Should monitor signal and cancel":
     var
       signal = ThreadSignalPtr.new().tryGet()
-      ctx = TaskCtx[void].new(
-        ds= sqlStore,
-        signal= signal)
+      ctx = TaskCtx[void].new( ds= sqlStore)
       fut = newFuture[void]("signalMonitor")
       threadArgs: (ptr TaskCtx[void], ptr Future[void]) = (addrOf(ctx), addr fut)
 
@@ -178,9 +176,7 @@ suite "Test ThreadDatastore cancelations":
   test "Should monitor and not cancel":
     var
       signal = ThreadSignalPtr.new().tryGet()
-      ctx = TaskCtx[void].new(
-        ds= sqlStore,
-        signal= signal)
+      ctx = TaskCtx[void].new( ds= sqlStore)
       fut = newFuture[void]("signalMonitor")
       threadArgs = (addrOf ctx, addr fut)
 


### PR DESCRIPTION
Experimenting with using TaskCtx flags and a `GC_ref` to handle corner case during cancellation. 

However, it seems to pull up some other issues with `Datastore` being a GC type and using it on multiple threads.
