### PR TITLE
Threadpool semaphore loop tests v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,8 +135,8 @@ jobs:
           echo
           nimble --verbose test
 
-      - name: Run memory tests
-        if: success() || failure()
-        run: |
-          source "${HOME}/.bash_env"
-          nim c -r tests/datastore/testthreadproxyds2.nim
+      # - name: Run memory tests
+      #   if: success() || failure()
+      #   run: |
+      #     source "${HOME}/.bash_env"
+      #     nim c -r tests/datastore/testthreadproxyds2.nim

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,3 +134,9 @@ jobs:
           nim --version
           echo
           nimble --verbose test
+
+      - name: Run memory tests
+        if: success() || failure()
+        run: |
+          source "${HOME}/.bash_env"
+          nim c -r tests/datastore/testthreadproxyds2.nim

--- a/datastore/memoryds.nim
+++ b/datastore/memoryds.nim
@@ -1,0 +1,133 @@
+import std/tables
+import std/sequtils
+import std/strutils
+import std/algorithm
+
+import pkg/chronos
+import pkg/questionable
+import pkg/questionable/results
+import pkg/upraises
+
+import ./key
+import ./query
+import ./datastore
+import ./threads/databuffer
+
+export key, query
+
+push: {.upraises: [].}
+
+type
+
+  MemoryDatastore* = ref object of Datastore
+    store*: Table[DataBuffer, DataBuffer]
+
+method has*(
+    self: MemoryDatastore,
+    key: Key
+): Future[?!bool] {.async.} =
+
+  let dk = DataBuffer.new(key.id())
+  return success self.store.hasKey(dk)
+
+method delete*(
+    self: MemoryDatastore,
+    key: Key
+): Future[?!void] {.async.} =
+
+  let dk = DataBuffer.new(key.id())
+  var val: DataBuffer
+  discard self.store.pop(dk, val)
+  return success()
+
+method delete*(
+  self: MemoryDatastore,
+  keys: seq[Key]): Future[?!void] {.async.} =
+
+  for key in keys:
+    if err =? (await self.delete(key)).errorOption:
+      return failure err
+
+  return success()
+
+method get*(
+    self: MemoryDatastore,
+    key: Key
+): Future[?!seq[byte]] {.async.} =
+
+  let dk = DataBuffer.new(key.id())
+  if self.store.hasKey(dk):
+    let res = self.store[dk].toSeq()
+    return success res
+  else:
+    return failure (ref DatastoreError)(msg: "no such key")
+
+method put*(
+    self: MemoryDatastore,
+    key: Key,
+    data: seq[byte]
+): Future[?!void] {.async.} =
+
+  let dk = DataBuffer.new(key.id())
+  let dv = DataBuffer.new(data)
+  self.store[dk] = dv
+  return success()
+
+method put*(
+  self: MemoryDatastore,
+  batch: seq[BatchEntry]): Future[?!void] {.async.} =
+
+  for entry in batch:
+    if err =? (await self.put(entry.key, entry.data)).errorOption:
+      return failure err
+
+  return success()
+
+proc keyIterator(self: MemoryDatastore, queryKey: string): iterator: DataBuffer {.gcsafe.} =
+  return iterator(): DataBuffer {.closure.} =
+    var keys = self.store.keys().toSeq()
+    keys.sort(proc (x, y: DataBuffer): int = cmp(x.toString, y.toString))
+    for key in keys:
+      if key.toString().startsWith(queryKey):
+        yield key 
+
+method query*(
+  self: MemoryDatastore,
+  query: Query,
+): Future[?!QueryIter] {.async.} =
+
+  let
+    queryKey = query.key.id()
+    walker = keyIterator(self, queryKey)
+  var
+    iter = QueryIter.new()
+  # iter.readyForNext = true
+
+  proc next(): Future[?!QueryResponse] {.async.} =
+    # iter.readyForNext = false
+    let kb = walker()
+    # iter.readyForNext = true
+
+    if finished(walker):
+      iter.finished = true
+      return success (Key.none, EmptyBytes)
+
+    let key = Key.init(kb.toString()).get()
+    var ds: DataBuffer
+    if query.value:
+      ds = self.store[kb]
+    let data = if ds.isNil: EmptyBytes else: ds.toSeq()
+
+    let res: tuple[key: ?Key, data: seq[byte]] = (key.some, data)
+    return success(res)
+
+  iter.next = next
+  return success iter
+
+method close*(self: MemoryDatastore): Future[?!void] {.async.} =
+  self.store.clear()
+  return success()
+
+func new*(tp: typedesc[MemoryDatastore]): MemoryDatastore =
+  var self = tp()
+  return self

--- a/tests/datastore/testmemoryds.nim
+++ b/tests/datastore/testmemoryds.nim
@@ -1,0 +1,37 @@
+import std/options
+import std/sequtils
+import std/os
+from std/algorithm import sort, reversed
+
+import pkg/asynctest
+import pkg/chronos
+import pkg/stew/results
+import pkg/stew/byteutils
+
+import pkg/datastore/memoryds
+
+import ./dscommontests
+import ./querycommontests
+
+suite "Test Basic MemoryDatastore":
+  let
+    key = Key.init("/a/b").tryGet()
+    bytes = "some bytes".toBytes
+    otherBytes = "some other bytes".toBytes
+
+  var
+    memStore: MemoryDatastore
+
+  setupAll:
+    memStore = MemoryDatastore.new()
+
+  basicStoreTests(memStore, key, bytes, otherBytes)
+
+suite "Test Query":
+
+  var ds: MemoryDatastore
+
+  setup:
+    ds = MemoryDatastore.new()
+
+  queryTests(ds, false)

--- a/tests/datastore/testthreadproxyds.nim
+++ b/tests/datastore/testthreadproxyds.nim
@@ -23,188 +23,204 @@ import ./querycommontests
 
 const NumThreads = 200 # IO threads aren't attached to CPU count
 
-suite "Test Basic ThreadDatastore with SQLite":
+proc testBasic() =
 
-  var
-    sqlStore: Datastore
-    ds: ThreadDatastore
-    taskPool: Taskpool
-    key = Key.init("/a/b").tryGet()
-    bytes = "some bytes".toBytes
-    otherBytes = "some other bytes".toBytes
-
-  setupAll:
-    sqlStore = SQLiteDatastore.new(Memory).tryGet()
-    taskPool = Taskpool.new(NumThreads)
-    ds = ThreadDatastore.new(sqlStore, tp = taskPool).tryGet()
-
-  teardownAll:
-    (await ds.close()).tryGet()
-    taskPool.shutdown()
-
-  basicStoreTests(ds, key, bytes, otherBytes)
-
-suite "Test Query ThreadDatastore with SQLite":
-
-  var
-    sqlStore: Datastore
-    ds: ThreadDatastore
-    taskPool: Taskpool
-    key = Key.init("/a/b").tryGet()
-    bytes = "some bytes".toBytes
-    otherBytes = "some other bytes".toBytes
-
-  setup:
-    sqlStore = SQLiteDatastore.new(Memory).tryGet()
-    taskPool = Taskpool.new(NumThreads)
-    ds = ThreadDatastore.new(sqlStore, tp = taskPool).tryGet()
-
-  teardown:
-    (await ds.close()).tryGet()
-    taskPool.shutdown()
-
-  queryTests(ds, true)
-
-suite "Test Basic ThreadDatastore with fsds":
-  let
-    path = currentSourcePath() # get this file's name
-    basePath = "tests_data"
-    basePathAbs = path.parentDir / basePath
-    key = Key.init("/a/b").tryGet()
-    bytes = "some bytes".toBytes
-    otherBytes = "some other bytes".toBytes
-
-  var
-    fsStore: FSDatastore
-    ds: ThreadDatastore
-    taskPool: Taskpool
-
-  setupAll:
-    removeDir(basePathAbs)
-    require(not dirExists(basePathAbs))
-    createDir(basePathAbs)
-
-    fsStore = FSDatastore.new(root = basePathAbs, depth = 3).tryGet()
-    taskPool = Taskpool.new(NumThreads)
-    ds = ThreadDatastore.new(fsStore, withLocks = true, tp = taskPool).tryGet()
-
-  teardownAll:
-    (await ds.close()).tryGet()
-    taskPool.shutdown()
-
-    removeDir(basePathAbs)
-    require(not dirExists(basePathAbs))
-
-  basicStoreTests(fsStore, key, bytes, otherBytes)
-
-suite "Test Query ThreadDatastore with fsds":
-  let
-    path = currentSourcePath() # get this file's name
-    basePath = "tests_data"
-    basePathAbs = path.parentDir / basePath
-
-  var
-    fsStore: FSDatastore
-    ds: ThreadDatastore
-    taskPool: Taskpool
-
-  setup:
-    removeDir(basePathAbs)
-    require(not dirExists(basePathAbs))
-    createDir(basePathAbs)
-
-    fsStore = FSDatastore.new(root = basePathAbs, depth = 5).tryGet()
-    taskPool = Taskpool.new(NumThreads)
-    ds = ThreadDatastore.new(fsStore, withLocks = true, tp = taskPool).tryGet()
-
-  teardown:
-    (await ds.close()).tryGet()
-    taskPool.shutdown()
-
-    removeDir(basePathAbs)
-    require(not dirExists(basePathAbs))
-
-  queryTests(ds, false)
-
-suite "Test ThreadDatastore cancelations":
-  var
-    sqlStore: Datastore
-    ds: ThreadDatastore
-    taskPool: Taskpool
-    key = Key.init("/a/b").tryGet()
-    bytes = "some bytes".toBytes
-    otherBytes = "some other bytes".toBytes
-
-  privateAccess(ThreadDatastore) # expose private fields
-  privateAccess(TaskCtx) # expose private fields
-
-  setupAll:
-    sqlStore = SQLiteDatastore.new(Memory).tryGet()
-    taskPool = Taskpool.new(NumThreads)
-    ds = ThreadDatastore.new(sqlStore, tp = taskPool).tryGet()
-
-  test "Should monitor signal and cancel":
-    var
-      signal = ThreadSignalPtr.new().tryGet()
-      res = ThreadResult[void]()
-      ctx = TaskCtx[void](
-        ds: sqlStore,
-        res: addr res,
-        signal: signal)
-      fut = newFuture[void]("signalMonitor")
-      threadArgs = (addr ctx, addr fut)
+  suite "Test Basic ThreadDatastore with SQLite":
 
     var
-      thread: Thread[type threadArgs]
+      sqlStore: Datastore
+      ds: ThreadDatastore
+      taskPool: Taskpool
+      key = Key.init("/a/b").tryGet()
+      bytes = "some bytes".toBytes
+      otherBytes = "some other bytes".toBytes
 
-    proc threadTask(args: type threadArgs) =
-      var (ctx, fut) = args
-      proc asyncTask() {.async.} =
-        let
-          monitor = signalMonitor(ctx, fut[])
+    setupAll:
+      sqlStore = SQLiteDatastore.new(Memory).tryGet()
+      taskPool = Taskpool.new(NumThreads)
+      ds = ThreadDatastore.new(sqlStore, tp = taskPool).tryGet()
 
-        await monitor
+    teardownAll:
+      (await ds.close()).tryGet()
+      taskPool.shutdown()
 
-      waitFor asyncTask()
+    basicStoreTests(ds, key, bytes, otherBytes)
+    GC_fullCollect()
 
-    createThread(thread, threadTask, threadArgs)
-    ctx.cancelled = true
-    check: ctx.signal.fireSync.tryGet
+for i in 1..100:
+  testBasic()
+  GC_fullCollect()
 
-    joinThreads(thread)
-
-    check: fut.cancelled
-    check: ctx.signal.close().isOk
-
-  test "Should monitor and not cancel":
-    var
-      signal = ThreadSignalPtr.new().tryGet()
-      res = ThreadResult[void]()
-      ctx = TaskCtx[void](
-        ds: sqlStore,
-        res: addr res,
-        signal: signal)
-      fut = newFuture[void]("signalMonitor")
-      threadArgs = (addr ctx, addr fut)
+proc testQuery() =
+  suite "Test Query ThreadDatastore with SQLite":
 
     var
-      thread: Thread[type threadArgs]
+      sqlStore: Datastore
+      ds: ThreadDatastore
+      taskPool: Taskpool
+      key = Key.init("/a/b").tryGet()
+      bytes = "some bytes".toBytes
+      otherBytes = "some other bytes".toBytes
 
-    proc threadTask(args: type threadArgs) =
-      var (ctx, fut) = args
-      proc asyncTask() {.async.} =
-        let
-          monitor = signalMonitor(ctx, fut[])
+    setup:
+      sqlStore = SQLiteDatastore.new(Memory).tryGet()
+      taskPool = Taskpool.new(NumThreads)
+      ds = ThreadDatastore.new(sqlStore, tp = taskPool).tryGet()
 
-        await monitor
+    teardown:
+      (await ds.close()).tryGet()
+      taskPool.shutdown()
 
-      waitFor asyncTask()
+    queryTests(ds, true)
+    GC_fullCollect()
 
-    createThread(thread, threadTask, threadArgs)
-    ctx.cancelled = false
-    check: ctx.signal.fireSync.tryGet
+for i in 1..100:
+  testQuery()
+  GC_fullCollect()
 
-    joinThreads(thread)
+proc testFsDs() =
+  suite "Test Basic ThreadDatastore with fsds":
+    let
+      path = currentSourcePath() # get this file's name
+      basePath = "tests_data"
+      basePathAbs = path.parentDir / basePath
+      key = Key.init("/a/b").tryGet()
+      bytes = "some bytes".toBytes
+      otherBytes = "some other bytes".toBytes
 
-    check: not fut.cancelled
-    check: ctx.signal.close().isOk
+    var
+      fsStore: FSDatastore
+      ds: ThreadDatastore
+      taskPool: Taskpool
+
+    setupAll:
+      removeDir(basePathAbs)
+      require(not dirExists(basePathAbs))
+      createDir(basePathAbs)
+
+      fsStore = FSDatastore.new(root = basePathAbs, depth = 3).tryGet()
+      taskPool = Taskpool.new(NumThreads)
+      ds = ThreadDatastore.new(fsStore, withLocks = true, tp = taskPool).tryGet()
+
+    teardownAll:
+      (await ds.close()).tryGet()
+      taskPool.shutdown()
+
+      removeDir(basePathAbs)
+      require(not dirExists(basePathAbs))
+
+    basicStoreTests(fsStore, key, bytes, otherBytes)
+
+proc testFsDsQuery() =
+  suite "Test Query ThreadDatastore with fsds":
+    let
+      path = currentSourcePath() # get this file's name
+      basePath = "tests_data"
+      basePathAbs = path.parentDir / basePath
+
+    var
+      fsStore: FSDatastore
+      ds: ThreadDatastore
+      taskPool: Taskpool
+
+    setup:
+      removeDir(basePathAbs)
+      require(not dirExists(basePathAbs))
+      createDir(basePathAbs)
+
+      fsStore = FSDatastore.new(root = basePathAbs, depth = 5).tryGet()
+      taskPool = Taskpool.new(NumThreads)
+      ds = ThreadDatastore.new(fsStore, withLocks = true, tp = taskPool).tryGet()
+
+    teardown:
+      (await ds.close()).tryGet()
+      taskPool.shutdown()
+
+      removeDir(basePathAbs)
+      require(not dirExists(basePathAbs))
+
+    queryTests(ds, false)
+
+proc testCancels() =
+  suite "Test ThreadDatastore cancelations":
+    var
+      sqlStore: Datastore
+      ds: ThreadDatastore
+      taskPool: Taskpool
+      key = Key.init("/a/b").tryGet()
+      bytes = "some bytes".toBytes
+      otherBytes = "some other bytes".toBytes
+
+    privateAccess(ThreadDatastore) # expose private fields
+    privateAccess(TaskCtx) # expose private fields
+
+    setupAll:
+      sqlStore = SQLiteDatastore.new(Memory).tryGet()
+      taskPool = Taskpool.new(NumThreads)
+      ds = ThreadDatastore.new(sqlStore, tp = taskPool).tryGet()
+
+    test "Should monitor signal and cancel":
+      var
+        signal = ThreadSignalPtr.new().tryGet()
+        res = ThreadResult[void]()
+        ctx = TaskCtx[void](
+          ds: sqlStore,
+          res: addr res,
+          signal: signal)
+        fut = newFuture[void]("signalMonitor")
+        threadArgs = (addr ctx, addr fut)
+
+      var
+        thread: Thread[type threadArgs]
+
+      proc threadTask(args: type threadArgs) =
+        var (ctx, fut) = args
+        proc asyncTask() {.async.} =
+          let
+            monitor = signalMonitor(ctx, fut[])
+
+          await monitor
+
+        waitFor asyncTask()
+
+      createThread(thread, threadTask, threadArgs)
+      ctx.cancelled = true
+      check: ctx.signal.fireSync.tryGet
+
+      joinThreads(thread)
+
+      check: fut.cancelled
+      check: ctx.signal.close().isOk
+
+    test "Should monitor and not cancel":
+      var
+        signal = ThreadSignalPtr.new().tryGet()
+        res = ThreadResult[void]()
+        ctx = TaskCtx[void](
+          ds: sqlStore,
+          res: addr res,
+          signal: signal)
+        fut = newFuture[void]("signalMonitor")
+        threadArgs = (addr ctx, addr fut)
+
+      var
+        thread: Thread[type threadArgs]
+
+      proc threadTask(args: type threadArgs) =
+        var (ctx, fut) = args
+        proc asyncTask() {.async.} =
+          let
+            monitor = signalMonitor(ctx, fut[])
+
+          await monitor
+
+        waitFor asyncTask()
+
+      createThread(thread, threadTask, threadArgs)
+      ctx.cancelled = false
+      check: ctx.signal.fireSync.tryGet
+
+      joinThreads(thread)
+
+      check: not fut.cancelled
+      check: ctx.signal.close().isOk

--- a/tests/datastore/testthreadproxyds.nim
+++ b/tests/datastore/testthreadproxyds.nim
@@ -48,7 +48,7 @@ proc testBasicSqllite() =
     basicStoreTests(ds, key, bytes, otherBytes)
     GC_fullCollect()
 
-for i in 1..100:
+for i in 1..200:
   testBasicSqllite()
   GC_fullCollect()
 
@@ -75,9 +75,9 @@ proc testQuerySqllite() =
     queryTests(ds, true)
     GC_fullCollect()
 
-# for i in 1..100:
-#   testQuerySqllite()
-#   GC_fullCollect()
+for i in 1..200:
+  testQuerySqllite()
+  GC_fullCollect()
 
 proc testFsDs() =
   suite "Test Basic ThreadDatastore with fsds":

--- a/tests/datastore/testthreadproxyds.nim
+++ b/tests/datastore/testthreadproxyds.nim
@@ -16,6 +16,7 @@ import pkg/chronicles
 
 import pkg/datastore/sql
 import pkg/datastore/fsds
+import pkg/datastore/memoryds
 import pkg/datastore/threads/threadproxyds {.all.}
 
 import ./dscommontests
@@ -23,7 +24,7 @@ import ./querycommontests
 
 const NumThreads = 200 # IO threads aren't attached to CPU count
 
-proc testBasic() =
+proc testBasicSqllite() =
 
   suite "Test Basic ThreadDatastore with SQLite":
 
@@ -48,10 +49,10 @@ proc testBasic() =
     GC_fullCollect()
 
 for i in 1..100:
-  testBasic()
+  testBasicSqllite()
   GC_fullCollect()
 
-proc testQuery() =
+proc testQuerySqllite() =
   suite "Test Query ThreadDatastore with SQLite":
 
     var
@@ -74,9 +75,9 @@ proc testQuery() =
     queryTests(ds, true)
     GC_fullCollect()
 
-for i in 1..100:
-  testQuery()
-  GC_fullCollect()
+# for i in 1..100:
+#   testQuerySqllite()
+#   GC_fullCollect()
 
 proc testFsDs() =
   suite "Test Basic ThreadDatastore with fsds":

--- a/tests/datastore/testthreadproxyds2.nim
+++ b/tests/datastore/testthreadproxyds2.nim
@@ -1,0 +1,53 @@
+import std/options
+import std/sequtils
+import std/os
+import std/cpuinfo
+import std/algorithm
+import std/importutils
+
+import pkg/asynctest
+import pkg/chronos
+import pkg/chronos/threadsync
+import pkg/stew/results
+import pkg/stew/byteutils
+import pkg/taskpools
+import pkg/questionable/results
+import pkg/chronicles
+
+import pkg/datastore/sql
+import pkg/datastore/fsds
+import pkg/datastore/memoryds
+import pkg/datastore/threads/threadproxyds {.all.}
+
+import ./dscommontests
+import ./querycommontests
+
+const NumThreads = 200 # IO threads aren't attached to CPU count
+
+proc testBasicMemory() =
+
+  suite "Test Basic ThreadDatastore with SQLite":
+
+    var
+      memStore: Datastore
+      ds: ThreadDatastore
+      taskPool: Taskpool
+      key = Key.init("/a/b").tryGet()
+      bytes = "some bytes".toBytes
+      otherBytes = "some other bytes".toBytes
+
+    setupAll:
+      memStore = MemoryDatastore.new()
+      taskPool = Taskpool.new(NumThreads)
+      ds = ThreadDatastore.new(memStore, tp = taskPool).tryGet()
+
+    teardownAll:
+      (await ds.close()).tryGet()
+      taskPool.shutdown()
+
+    basicStoreTests(ds, key, bytes, otherBytes)
+    GC_fullCollect()
+
+for i in 1..1000:
+  testBasicMemory()
+  GC_fullCollect()

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -6,6 +6,7 @@ import
   ./datastore/testtieredds,
   ./datastore/testmountedds,
   ./datastore/testdatabuffer,
+  ./datastore/testthreadproxyds2,
   ./datastore/testthreadproxyds,
   ./datastore/testasyncsemaphore,
   ./datastore/testsemaphore


### PR DESCRIPTION
Testing loop tests with memoryds. 

Locally I'm getting:

```ruby
[Suite] Test Basic ThreadDatastore with SQLite
[OK] put
[OK] get
[OK] put update
[OK] get updated
[OK] delete
[OK] contains
[OK] put batch
[OK] delete batch
[OK] handle missing key
Traceback (most recent call last)
/Users/jaremycreechley/projs/status/nim-codex/vendor/nim-datastore/tests/datastore/testthreadproxyds2.nim(51) testthreadproxyds2
/Users/jaremycreechley/.asdf/installs/nim/1.6.14/lib/system/gc_common.nim(429) prepareDealloc
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
``` 