### PR TITLE
Updates for Chronos V4

### DIFF
--- a/datastore.nimble
+++ b/datastore.nimble
@@ -8,7 +8,7 @@ license       = "Apache License 2.0 or MIT"
 
 requires "nim >= 1.2.0",
          "asynctest >= 0.4.3 & < 0.5.0",
-         "chronos#head", # FIXME change to Chronos >= 4.0.0 once it's out
+         "chronos#c41599a", # FIXME change to Chronos >= 4.0.0 once it's out
          "questionable >= 0.10.3 & < 0.11.0",
          "sqlite3_abi",
          "stew",

--- a/datastore.nimble
+++ b/datastore.nimble
@@ -7,7 +7,7 @@ description   = "Simple, unified API for multiple data stores"
 license       = "Apache License 2.0 or MIT"
 
 requires "nim >= 1.2.0",
-         "asynctest >= 0.3.1 & < 0.4.0",
+         "asynctest >= 0.4.3 & < 0.5.0",
          "chronos",
          "questionable >= 0.10.3 & < 0.11.0",
          "sqlite3_abi",

--- a/datastore.nimble
+++ b/datastore.nimble
@@ -8,7 +8,7 @@ license       = "Apache License 2.0 or MIT"
 
 requires "nim >= 1.2.0",
          "asynctest >= 0.4.3 & < 0.5.0",
-         "chronos",
+         "chronos#head", # FIXME change to Chronos >= 4.0.0 once it's out
          "questionable >= 0.10.3 & < 0.11.0",
          "sqlite3_abi",
          "stew",

--- a/datastore/fsds.nim
+++ b/datastore/fsds.nim
@@ -154,7 +154,7 @@ method put*(
 
   return success()
 
-proc dirWalker(path: string): iterator: string {.gcsafe.} =
+proc dirWalker(path: string): (iterator: string {.raises: [Defect], gcsafe.}) =
   return iterator(): string =
     try:
       for p in path.walkDirRec(yieldFilter = {pcFile}, relative = true):


### PR DESCRIPTION
This PR adds minor exception effect annotations so that datastore is compatible with Chronos V4. It also explicitly tracks chronos#head in the nimble file until Chronos 4.0.0 is officially out as we'll otherwise get misleading CI results.