### PR TITLE
Add some exports to typedds.nim

### DIFF
--- a/datastore/typedds.nim
+++ b/datastore/typedds.nim
@@ -7,6 +7,8 @@ import pkg/chronos
 import pkg/chronos/futures
 
 import ./datastore
+import ./types
+import ./key
 
 ## Wrapper for Datastore with basic functionality of automatically converting
 ## stored values from some user defined type `T` to `seq[byte]` and vice-versa.
@@ -52,6 +54,8 @@ type
     finished*: bool
     next*: GetNext[T]
     dispose*: IterDispose
+
+export types, key, IterDispose, Key, Query, SortOrder, QueryEndedError
 
 # Helpers
 template requireDecoder*(T: typedesc): untyped =


### PR DESCRIPTION
These exports are useful when client code imports only the `typedds`