### PR TITLE
Tests for concurrent queries. Finishes disposed iterators.

### DIFF
--- a/datastore/fsds.nim
+++ b/datastore/fsds.nim
@@ -190,6 +190,9 @@ method query*(
     iter = QueryIter.new()
 
   proc next(): Future[?!QueryResponse] {.async.} =
+    if iter.finished:
+      return success (Key.none, EmptyBytes)
+
     let
       path = walker()
 

--- a/datastore/fsds.nim
+++ b/datastore/fsds.nim
@@ -216,6 +216,10 @@ method query*(
     return success (key.some, data)
 
   iter.next = next
+  iter.dispose = proc(): Future[?!void] {.async.} =
+    iter.finished = true
+    return success()
+  
   return success iter
 
 method modifyGet*(

--- a/datastore/leveldb/leveldbds.nim
+++ b/datastore/leveldb/leveldbds.nim
@@ -116,6 +116,7 @@ method query*(
 
   proc dispose(): Future[?!void] {.async.} =
     dbIter.dispose()
+    iter.finished = true
     return success()
 
   iter.next = next

--- a/datastore/leveldb/leveldbds.nim
+++ b/datastore/leveldb/leveldbds.nim
@@ -100,7 +100,7 @@ method query*(
 
   proc next(): Future[?!QueryResponse] {.async.} =
     if iter.finished:
-      return failure(newException(QueryEndedError, "Calling next on a finished query!"))
+      return success (Key.none, EmptyBytes)
 
     try:
       let (keyStr, valueStr) = dbIter.next()

--- a/datastore/sql/sqliteds.nim
+++ b/datastore/sql/sqliteds.nim
@@ -269,7 +269,7 @@ method query*(
 
   proc next(): Future[?!QueryResponse] {.async.} =
     if iter.finished:
-      return failure(newException(QueryEndedError, "Calling next on a finished query!"))
+      return success (Key.none, EmptyBytes)
 
     let
       v = sqlite3_step(s)
@@ -324,7 +324,6 @@ method query*(
   iter.dispose = proc(): Future[?!void] {.async.} =
     discard sqlite3_reset(s)
     discard sqlite3_clear_bindings(s)
-    iter.next = nil
     iter.finished = true
     return success()
 

--- a/datastore/sql/sqliteds.nim
+++ b/datastore/sql/sqliteds.nim
@@ -325,6 +325,7 @@ method query*(
     discard sqlite3_reset(s)
     discard sqlite3_clear_bindings(s)
     iter.next = nil
+    iter.finished = true
     return success()
 
   iter.next = next

--- a/tests/datastore/querycommontests.nim
+++ b/tests/datastore/querycommontests.nim
@@ -143,6 +143,39 @@ template queryTests*(ds: Datastore, testLimitsAndOffsets = true, testSortOrder =
     (await iter1.dispose()).tryGet
     (await iter2.dispose()).tryGet
 
+  test "Dispose should discontinue iteration":
+    let
+      q1 = Query.init(key1)
+
+    (await ds.put(key1, val1)).tryGet
+    (await ds.put(key2, val2)).tryGet
+    (await ds.put(key3, val3)).tryGet
+
+    let
+      iter = (await ds.query(q1)).tryGet
+
+    let one = (await iter.next()).tryGet
+    check not iter.finished
+
+    let two = (await iter.next()).tryGet
+    check not iter.finished
+
+    (await iter.dispose()).tryGet
+    check iter.finished
+
+    let three = (await iter.next()).tryGet
+    check iter.finished
+
+    let four = (await iter.next()).tryGet
+    check iter.finished
+
+    check:
+      one[0].get == key1
+      one[1] == val1
+      two[0].get == key2
+      two[1] == val2
+      three[0] == Key.none
+      four[0] == Key.none
 
   test "Key should query all keys without values":
     let


### PR DESCRIPTION
During debugging, I wrote these tests to check that the datastores can handle concurrent queries.
This didn't help. It didn't reveal any problems. But I figure we might as well keep the tests.
