### PR TITLE
Simplifies tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,9 @@
 name: Tests
-
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-  workflow_dispatch:
-
+on: [push, pull_request]
 jobs:
-  tests:
+  test:
     strategy:
-      fail-fast: false
       matrix:
-        cache_nonce: [ 1 ]
-        nim_version: [ 1.6.18 ]
         platform:
           - {
             icon: 🐧,
@@ -33,105 +23,17 @@ jobs:
             os: windows,
             shell: msys2
           }
+        nim: [1.6.18]
     name: ${{ matrix.platform.icon }} ${{ matrix.platform.label }} - Nim v${{ matrix.nim_version }}
     runs-on: ${{ matrix.platform.os }}-latest
-    defaults:
-      run:
-        shell: ${{ matrix.platform.shell }} {0}
-
     steps:
-      - name: Install tools and libraries via APT (Linux)
-        if: matrix.platform.os == 'ubuntu'
-        run: |
-          # sudo apt update
-          # sudo apt install -y \
-          #   ...
-
-      - name: Install tools and libraries via Homebrew (macOS)
-        if: matrix.platform.os == 'macos'
-        run: |
-          brew install \
-            findutils
-
-      - name: Install tools and libraries via MSYS2 (Windows)
-        if: matrix.platform.os == 'windows'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: UCRT64
-          install: >
-            base-devel
-            git
-            mingw-w64-ucrt-x86_64-toolchain
-            mingw-w64-ucrt-x86_64-cmake
-
-      - name: Checkout sources from GitHub
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Calculate cache member paths
-        id: calc-paths
-        run: |
-          if [[ ${{ matrix.platform.os }} = windows ]]; then
-            echo "::set-output name=bash_env::$(cygpath -m "${HOME}")/.bash_env"
-            echo "::set-output name=choosenim::$(cygpath -m "${USERPROFILE}")/.choosenim"
-            echo "::set-output name=nimble::$(cygpath -m "${HOME}")/.nimble"
-          else
-            echo "::set-output name=bash_env::${HOME}/.bash_env"
-            echo "::set-output name=choosenim::${HOME}/.choosenim"
-            echo "::set-output name=nimble::${HOME}/.nimble"
-          fi
-
-      - name: Restore choosenim and Nim tooling from cache
-        id: choosenim-nim-tooling-cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.calc-paths.outputs.bash_env }}
-            ${{ steps.calc-paths.outputs.choosenim }}
-            ${{ steps.calc-paths.outputs.nimble }}/bin
-          key: ${{ matrix.platform.os }}-nim_version:${{ matrix.nim_version }}-cache_nonce:${{ matrix.cache_nonce }}
-
-      - name: Install choosenim and Nim tooling
-        if: steps.choosenim-nim-tooling-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "${HOME}/Downloads"
-          cd "${HOME}/Downloads"
-          curl https://nim-lang.org/choosenim/init.sh -sSf -O
-          chmod +x init.sh
-          if [[ ${{ matrix.platform.os }} = windows ]]; then
-            mkdir -p "$(cygpath "${USERPROFILE}")/.nimble/bin"
-          fi
-          CHOOSENIM_CHOOSE_VERSION=${{ matrix.nim_version }} ./init.sh -y
-          if [[ ${{ matrix.platform.os }} = windows ]]; then
-            mv "$(cygpath "${USERPROFILE}")/.nimble" "${HOME}/"
-            # intention is to rely only on libs provided by the OS and MSYS2 env
-            rm -rf "${HOME}/.nimble/bin/"*.dll
-            rm -rf "${HOME}/.nimble/bin/"*.pem
-          fi
-          echo 'export NIMBLE_DIR="${HOME}/.nimble"' >> "${HOME}/.bash_env"
-          echo 'export PATH="${NIMBLE_DIR}/bin:${PATH}"' >> "${HOME}/.bash_env"
-
-      - name: Install project dependencies
-        run: |
-          source "${HOME}/.bash_env"
-          cd "${NIMBLE_DIR}/bin"
-          # delete broken symlinks, which can arise because e.g. the cache
-          # restored a symlink that points to an executable within
-          # ../pkgs/foo-1.2.3/ but the project's .nimble file has been updated
-          # to install foo-#head; in the case of a broken symlink, nimble's
-          # auto-overwrite fails
-          if [[ ${{ matrix.platform.os }} = macos ]]; then
-            gfind . -xtype l -delete
-          else
-            find . -xtype l -delete
-          fi
-          cd -
-          nimble --accept install
-
-      - name: Build and run tests
-        run: |
-          source "${HOME}/.bash_env"
-          nim --version
-          echo
-          nimble --verbose test
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: iffy/install-nim@v4
+      with:
+        version: ${{ matrix.nim }}
+    - name: Build
+      run: nimble install -y
+    - name: Test
+      run: nimble test -y

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
             shell: msys2
           }
         nim: [1.6.18]
-    name: ${{ matrix.platform.icon }} ${{ matrix.platform.label }} - Nim v${{ matrix.nim_version }}
+    name: ${{ matrix.platform.icon }} ${{ matrix.platform.label }} - Nim v${{ matrix.nim }}
     runs-on: ${{ matrix.platform.os }}-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     name: ${{ matrix.platform.icon }} ${{ matrix.platform.label }} - Nim v${{ matrix.nim }}
     runs-on: ${{ matrix.platform.os }}-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: iffy/install-nim@v4


### PR DESCRIPTION
This is done in response to choosenim's download URL breaking and causing the CI to fail.
Mark suggested replacing choosenim with a iffy nim-specific github action. This is already being used in several other repositories. So this PR rolls out the same solution.
