### PR TITLE
fix: close pending iterators before closing LevelDB store

### DIFF
--- a/datastore/leveldb/leveldbds.nim
+++ b/datastore/leveldb/leveldbds.nim
@@ -98,6 +98,11 @@ method query*(
       limit = query.limit
     )
 
+  proc dispose(): Future[?!void] {.async: (raises: [CancelledError]).} =
+    dbIter.dispose()
+    iter.disposed = true
+    return success()
+
   proc next(): Future[?!QueryResponse] {.async: (raises: [CancelledError]).} =
     if iter.finished:
       return failure(newException(QueryEndedError, "Calling next on a finished query!"))
@@ -107,16 +112,15 @@ method query*(
 
       if dbIter.finished:
         iter.finished = true
+        if err =? (await dispose()).errorOption:
+          return failure(err)
+
         return success (Key.none, EmptyBytes)
       else:
         let key = Key.init(keyStr).expect("LevelDbDatastore.query (next) Failed to create key.")
         return success (key.some, valueStr.toBytes())
     except LevelDbException as e:
       return failure("LevelDbDatastore.query -> next exception: " & $e.msg)
-
-  proc dispose(): Future[?!void] {.async: (raises: [CancelledError]).} =
-    dbIter.dispose()
-    return success()
 
   iter.next = next
   iter.dispose = dispose

--- a/datastore/leveldb/leveldbds.nim
+++ b/datastore/leveldb/leveldbds.nim
@@ -5,6 +5,7 @@ import std/tables
 import std/os
 import std/strformat
 import std/strutils
+import std/sets
 
 import pkg/leveldbstatic
 import pkg/chronos
@@ -19,6 +20,10 @@ type
   LevelDbDatastore* = ref object of Datastore
     db: LevelDb
     locks: TableRef[Key, AsyncLock]
+    openIterators: HashSet[QueryIter]
+
+proc hash(iter: QueryIter): Hash =
+  hash(addr iter)
 
 method has*(self: LevelDbDatastore, key: Key): Future[?!bool] {.async: (raises: [CancelledError]).} =
   try:
@@ -70,6 +75,10 @@ method put*(self: LevelDbDatastore, batch: seq[BatchEntry]): Future[?!void] {.as
 
 method close*(self: LevelDbDatastore): Future[?!void] {.async: (raises: [CancelledError]).} =
   try:
+    for iter in self.openIterators:
+      if err =? (await iter.dispose()).errorOption:
+        return failure(err.msg)
+    self.openIterators.clear()
     self.db.close()
     return success()
   except LevelDbException as e:
@@ -101,6 +110,8 @@ method query*(
   proc dispose(): Future[?!void] {.async: (raises: [CancelledError]).} =
     dbIter.dispose()
     iter.disposed = true
+    self.openIterators.excl(iter)
+
     return success()
 
   proc next(): Future[?!QueryResponse] {.async: (raises: [CancelledError]).} =
@@ -124,6 +135,8 @@ method query*(
 
   iter.next = next
   iter.dispose = dispose
+  self.openIterators.incl(iter)
+
   return success iter
 
 method modifyGet*(

--- a/datastore/query.nim
+++ b/datastore/query.nim
@@ -27,6 +27,7 @@ type
   IterDispose* = proc(): Future[?!void] {.async: (raises: [CancelledError]), gcsafe.}
   QueryIter* = ref object
     finished*: bool
+    disposed*: bool
     next*: GetNext
     dispose*: IterDispose
 

--- a/tests/datastore/leveldb/testleveldbds.nim
+++ b/tests/datastore/leveldb/testleveldbds.nim
@@ -97,64 +97,64 @@ suite "LevelDB Query":
     (await ds.close()).tryGet
     removeDir(tempDir)
 
-  # test "should query by prefix":
-  #   let
-  #     q = Query.init(Key.init("/a/*").tryGet)
-  #     iter = (await ds.query(q)).tryGet
-  #     res = (await allFinished(toSeq(iter)))
-  #       .mapIt( it.read.tryGet )
-  #       .filterIt( it.key.isSome )
+  test "should query by prefix":
+    let
+      q = Query.init(Key.init("/a/*").tryGet)
+      iter = (await ds.query(q)).tryGet
+      res = (await allFinished(toSeq(iter)))
+        .mapIt( it.read.tryGet )
+        .filterIt( it.key.isSome )
 
-  #   check:
-  #     res.len == 3
-  #     res[0].key.get == key1
-  #     res[0].data == val1
+    check:
+      res.len == 3
+      res[0].key.get == key1
+      res[0].data == val1
 
-  #     res[1].key.get == key2
-  #     res[1].data == val2
+      res[1].key.get == key2
+      res[1].data == val2
 
-  #     res[2].key.get == key3
-  #     res[2].data == val3
+      res[2].key.get == key3
+      res[2].data == val3
 
-  #   (await iter.dispose()).tryGet
+    (await iter.dispose()).tryGet
 
-  # test "should disregard forward trailing wildcards in keys":
-  #   let
-  #     q = Query.init(Key.init("/a/*").tryGet)
-  #     iter = (await ds.query(q)).tryGet
-  #     res = (await allFinished(toSeq(iter)))
-  #       .mapIt( it.read.tryGet )
-  #       .filterIt( it.key.isSome )
+  test "should disregard forward trailing wildcards in keys":
+    let
+      q = Query.init(Key.init("/a/*").tryGet)
+      iter = (await ds.query(q)).tryGet
+      res = (await allFinished(toSeq(iter)))
+        .mapIt( it.read.tryGet )
+        .filterIt( it.key.isSome )
 
-  #   check:
-  #     res.len == 3
-  #     res[0].key.get == key1
-  #     res[0].data == val1
+    check:
+      res.len == 3
+      res[0].key.get == key1
+      res[0].data == val1
 
-  #     res[1].key.get == key2
-  #     res[1].data == val2
+      res[1].key.get == key2
+      res[1].data == val2
 
-  #     res[2].key.get == key3
-  #     res[2].data == val3
+      res[2].key.get == key3
+      res[2].data == val3
 
-  # test "should disregard backward trailing wildcards in key":
-  #   let
-  #     q = Query.init(Key.init("/a\\*").tryGet)
-  #     iter = (await ds.query(q)).tryGet
-  #     res = (await allFinished(toSeq(iter)))
-  #       .mapIt( it.read.tryGet )
-  #       .filterIt( it.key.isSome )
+  test "should disregard backward trailing wildcards in key":
+    let
+      q = Query.init(Key.init("/a\\*").tryGet)
+      iter = (await ds.query(q)).tryGet
+      res = (await allFinished(toSeq(iter)))
+        .mapIt( it.read.tryGet )
+        .filterIt( it.key.isSome )
 
-  #   check:
-  #     res.len == 3
-  #     res[0].key.get == key1
-  #     res[0].data == val1
+    check:
+      res.len == 3
+      res[0].key.get == key1
+      res[0].data == val1
 
-  #     res[1].key.get == key2
-  #     res[1].data == val2
+      res[1].key.get == key2
+      res[1].data == val2
 
-  #     res[2].key.get == key3
-  #     res[2].data == val3
+      res[2].key.get == key3
+      res[2].data == val3
 
   test "should dispose automatically when iterator is finished":
     let
@@ -174,3 +174,24 @@ suite "LevelDB Query":
 
     check iter.finished == true
     check iter.disposed == true
+
+  test "should dispose automatically of iterators when datastore is closed":
+    let
+      q1 = Query.init(Key.init("/a/b/c").tryGet)
+      q2 = Query.init(Key.init("/a/b").tryGet)
+      i1 = (await ds.query(q1)).tryGet
+      i2 = (await ds.query(q2)).tryGet
+
+    check i1.disposed == false
+    check i2.disposed == false
+
+    (await ds.close()).tryGet
+
+    check i1.disposed == true
+    check i2.disposed == true
+
+  test "should have idempotent QueryIterator.dispose":
+    let q = Query.init(Key.init("/a/b/c").tryGet)
+    let iter = (await ds.query(q)).tryGet
+    (await iter.dispose()).tryGet
+    (await iter.dispose()).tryGet

--- a/tests/datastore/leveldb/testleveldbds.nim
+++ b/tests/datastore/leveldb/testleveldbds.nim
@@ -16,58 +16,58 @@ import ../modifycommontests
 import ../querycommontests
 import ../typeddscommontests
 
-suite "Test Basic LevelDbDatastore":
-  let
-    tempDir = getTempDir() / "testleveldbds"
-    ds = LevelDbDatastore.new(tempDir).tryGet()
-    key = Key.init("a:b/c/d:e").tryGet()
-    bytes = "some bytes".toBytes
-    otherBytes = "some other bytes".toBytes
+# suite "Test Basic LevelDbDatastore":
+#   let
+#     tempDir = getTempDir() / "testleveldbds"
+#     ds = LevelDbDatastore.new(tempDir).tryGet()
+#     key = Key.init("a:b/c/d:e").tryGet()
+#     bytes = "some bytes".toBytes
+#     otherBytes = "some other bytes".toBytes
 
-  setupAll:
-    createDir(tempDir)
+#   setupAll:
+#     createDir(tempDir)
 
-  teardownAll:
-    (await ds.close()).tryGet()
-    removeDir(tempDir)
+#   teardownAll:
+#     (await ds.close()).tryGet()
+#     removeDir(tempDir)
 
-  basicStoreTests(ds, key, bytes, otherBytes)
-  modifyTests(ds, key)
-  typedDsTests(ds, key)
+#   basicStoreTests(ds, key, bytes, otherBytes)
+#   modifyTests(ds, key)
+#   typedDsTests(ds, key)
 
-suite "Test LevelDB Query":
-  let tempDir = getTempDir() / "testleveldbds"
-  var ds: LevelDbDatastore
+# suite "Test LevelDB Query":
+#   let tempDir = getTempDir() / "testleveldbds"
+#   var ds: LevelDbDatastore
 
-  setup:
-    createDir(tempDir)
-    ds = LevelDbDatastore.new(tempDir).tryGet()
+#   setup:
+#     createDir(tempDir)
+#     ds = LevelDbDatastore.new(tempDir).tryGet()
 
-  teardown:
-    (await ds.close()).tryGet
-    removeDir(tempDir)
+#   teardown:
+#     (await ds.close()).tryGet
+#     removeDir(tempDir)
 
-  queryTests(ds,
-    testLimitsAndOffsets = true,
-    testSortOrder = false
-  )
+#   queryTests(ds,
+#     testLimitsAndOffsets = true,
+#     testSortOrder = false
+#   )
 
-suite "Test LevelDB Typed Query":
-  let tempDir = getTempDir() / "testleveldbds"
-  var ds: LevelDbDatastore
+# suite "Test LevelDB Typed Query":
+#   let tempDir = getTempDir() / "testleveldbds"
+#   var ds: LevelDbDatastore
 
-  setup:
-    createDir(tempDir)
-    ds = LevelDbDatastore.new(tempDir).tryGet()
+#   setup:
+#     createDir(tempDir)
+#     ds = LevelDbDatastore.new(tempDir).tryGet()
 
-  teardown:
-    (await ds.close()).tryGet
-    removeDir(tempDir)
+#   teardown:
+#     (await ds.close()).tryGet
+#     removeDir(tempDir)
 
-  test "Typed Queries":
-    typedDsQueryTests(ds)
+#   test "Typed Queries":
+#     typedDsQueryTests(ds)
 
-suite "LevelDB Query: keys should disregard trailing wildcards":
+suite "LevelDB Query":
   let tempDir = getTempDir() / "testleveldbds"
   var
     ds: LevelDbDatastore
@@ -97,44 +97,80 @@ suite "LevelDB Query: keys should disregard trailing wildcards":
     (await ds.close()).tryGet
     removeDir(tempDir)
 
-  test "Forward":
+  # test "should query by prefix":
+  #   let
+  #     q = Query.init(Key.init("/a/*").tryGet)
+  #     iter = (await ds.query(q)).tryGet
+  #     res = (await allFinished(toSeq(iter)))
+  #       .mapIt( it.read.tryGet )
+  #       .filterIt( it.key.isSome )
+
+  #   check:
+  #     res.len == 3
+  #     res[0].key.get == key1
+  #     res[0].data == val1
+
+  #     res[1].key.get == key2
+  #     res[1].data == val2
+
+  #     res[2].key.get == key3
+  #     res[2].data == val3
+
+  #   (await iter.dispose()).tryGet
+
+  # test "should disregard forward trailing wildcards in keys":
+  #   let
+  #     q = Query.init(Key.init("/a/*").tryGet)
+  #     iter = (await ds.query(q)).tryGet
+  #     res = (await allFinished(toSeq(iter)))
+  #       .mapIt( it.read.tryGet )
+  #       .filterIt( it.key.isSome )
+
+  #   check:
+  #     res.len == 3
+  #     res[0].key.get == key1
+  #     res[0].data == val1
+
+  #     res[1].key.get == key2
+  #     res[1].data == val2
+
+  #     res[2].key.get == key3
+  #     res[2].data == val3
+
+  # test "should disregard backward trailing wildcards in key":
+  #   let
+  #     q = Query.init(Key.init("/a\\*").tryGet)
+  #     iter = (await ds.query(q)).tryGet
+  #     res = (await allFinished(toSeq(iter)))
+  #       .mapIt( it.read.tryGet )
+  #       .filterIt( it.key.isSome )
+
+  #   check:
+  #     res.len == 3
+  #     res[0].key.get == key1
+  #     res[0].data == val1
+
+  #     res[1].key.get == key2
+  #     res[1].data == val2
+
+  #     res[2].key.get == key3
+  #     res[2].data == val3
+
+  test "should dispose automatically when iterator is finished":
     let
-      q = Query.init(Key.init("/a/*").tryGet)
+      q = Query.init(Key.init("/a/b/c").tryGet)
       iter = (await ds.query(q)).tryGet
-      res = (await allFinished(toSeq(iter)))
-        .mapIt( it.read.tryGet )
-        .filterIt( it.key.isSome )
 
-    check:
-      res.len == 3
-      res[0].key.get == key1
-      res[0].data == val1
+    let val = (await iter.next()).tryGet()
+    check val.key.get == key3
+    check val.data == val3
 
-      res[1].key.get == key2
-      res[1].data == val2
+    check iter.finished == false
+    check iter.disposed == false
 
-      res[2].key.get == key3
-      res[2].data == val3
+    let val2 = (await iter.next()).tryGet()
+    check val2.key == Key.none
+    check val2.data == EmptyBytes
 
-    (await iter.dispose()).tryGet
-
-  test "Backwards":
-    let
-      q = Query.init(Key.init("/a\\*").tryGet)
-      iter = (await ds.query(q)).tryGet
-      res = (await allFinished(toSeq(iter)))
-        .mapIt( it.read.tryGet )
-        .filterIt( it.key.isSome )
-
-    check:
-      res.len == 3
-      res[0].key.get == key1
-      res[0].data == val1
-
-      res[1].key.get == key2
-      res[1].data == val2
-
-      res[2].key.get == key3
-      res[2].data == val3
-
-    (await iter.dispose()).tryGet
+    check iter.finished == true
+    check iter.disposed == true

--- a/tests/datastore/leveldb/testleveldbds.nim
+++ b/tests/datastore/leveldb/testleveldbds.nim
@@ -16,56 +16,56 @@ import ../modifycommontests
 import ../querycommontests
 import ../typeddscommontests
 
-# suite "Test Basic LevelDbDatastore":
-#   let
-#     tempDir = getTempDir() / "testleveldbds"
-#     ds = LevelDbDatastore.new(tempDir).tryGet()
-#     key = Key.init("a:b/c/d:e").tryGet()
-#     bytes = "some bytes".toBytes
-#     otherBytes = "some other bytes".toBytes
+suite "Test Basic LevelDbDatastore":
+  let
+    tempDir = getTempDir() / "testleveldbds"
+    ds = LevelDbDatastore.new(tempDir).tryGet()
+    key = Key.init("a:b/c/d:e").tryGet()
+    bytes = "some bytes".toBytes
+    otherBytes = "some other bytes".toBytes
 
-#   setupAll:
-#     createDir(tempDir)
+  setupAll:
+    createDir(tempDir)
 
-#   teardownAll:
-#     (await ds.close()).tryGet()
-#     removeDir(tempDir)
+  teardownAll:
+    (await ds.close()).tryGet()
+    removeDir(tempDir)
 
-#   basicStoreTests(ds, key, bytes, otherBytes)
-#   modifyTests(ds, key)
-#   typedDsTests(ds, key)
+  basicStoreTests(ds, key, bytes, otherBytes)
+  modifyTests(ds, key)
+  typedDsTests(ds, key)
 
-# suite "Test LevelDB Query":
-#   let tempDir = getTempDir() / "testleveldbds"
-#   var ds: LevelDbDatastore
+suite "Test LevelDB Query":
+  let tempDir = getTempDir() / "testleveldbds"
+  var ds: LevelDbDatastore
 
-#   setup:
-#     createDir(tempDir)
-#     ds = LevelDbDatastore.new(tempDir).tryGet()
+  setup:
+    createDir(tempDir)
+    ds = LevelDbDatastore.new(tempDir).tryGet()
 
-#   teardown:
-#     (await ds.close()).tryGet
-#     removeDir(tempDir)
+  teardown:
+    (await ds.close()).tryGet
+    removeDir(tempDir)
 
-#   queryTests(ds,
-#     testLimitsAndOffsets = true,
-#     testSortOrder = false
-#   )
+  queryTests(ds,
+    testLimitsAndOffsets = true,
+    testSortOrder = false
+  )
 
-# suite "Test LevelDB Typed Query":
-#   let tempDir = getTempDir() / "testleveldbds"
-#   var ds: LevelDbDatastore
+suite "Test LevelDB Typed Query":
+  let tempDir = getTempDir() / "testleveldbds"
+  var ds: LevelDbDatastore
 
-#   setup:
-#     createDir(tempDir)
-#     ds = LevelDbDatastore.new(tempDir).tryGet()
+  setup:
+    createDir(tempDir)
+    ds = LevelDbDatastore.new(tempDir).tryGet()
 
-#   teardown:
-#     (await ds.close()).tryGet
-#     removeDir(tempDir)
+  teardown:
+    (await ds.close()).tryGet
+    removeDir(tempDir)
 
-#   test "Typed Queries":
-#     typedDsQueryTests(ds)
+  test "Typed Queries":
+    typedDsQueryTests(ds)
 
 suite "LevelDB Query":
   let tempDir = getTempDir() / "testleveldbds"

--- a/tests/datastore/leveldb/testleveldbds.nim
+++ b/tests/datastore/leveldb/testleveldbds.nim
@@ -99,7 +99,7 @@ suite "LevelDB Query":
 
   test "should query by prefix":
     let
-      q = Query.init(Key.init("/a/*").tryGet)
+      q = Query.init(Key.init("/a").tryGet)
       iter = (await ds.query(q)).tryGet
       res = (await allFinished(toSeq(iter)))
         .mapIt( it.read.tryGet )

--- a/tests/datastore/leveldb/testleveldbds.nim
+++ b/tests/datastore/leveldb/testleveldbds.nim
@@ -156,7 +156,7 @@ suite "LevelDB Query":
       res[2].key.get == key3
       res[2].data == val3
 
-  test "should dispose automatically when iterator is finished":
+  test "should dispose automatically of iterators when finished":
     let
       q = Query.init(Key.init("/a/b/c").tryGet)
       iter = (await ds.query(q)).tryGet


### PR DESCRIPTION
This PR adds tracking of open iterators to leveldbds so that when one attempts to close it, iterators are disposed of first. It also adds automatic disposal if iterators are completely consumed.

fixes #82 